### PR TITLE
feat(rules): add a typecheck option to coco_package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,8 +95,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: "projects/1087051700446/locations/global/workloadIdentityPools/github-dev-pool/providers/github-cocotec"
-          service_account: "gh-cocotec-rules-coco-ki7h@dev-773ceb2b.iam.gserviceaccount.com"
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: "Upload to dl.cocotec.io"
         uses: google-github-actions/upload-cloud-storage@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2024
+
+Initial public release of Bazel rules for Popili.
+
+### Added
+
+#### Core Rules
+
+- `coco_package` - Define Coco packages from Coco.toml and .coco source files (supports `typecheck` attribute)
+- `coco_generate` - Generate code from Coco packages
+- `coco_cc_library` - Build C++ libraries from generated code (includes runtime automatically)
+- `coco_cc_test_library` - Build C++ test libraries with gMocks.
+- `coco_verify_test` - Run Popili verification as a Bazel test
+- `coco_fmt_test` - Check formatting and format code in-place
+- `with_popili_version` - Build targets with specific Popili versions
+
+#### Build System Support
+
+- bzlmod support for Bazel 8.0.0+ (recommended)
+- WORKSPACE support (deprecated, will be removed in future versions)
+- Multi-version support: Use multiple Popili versions in the same workspace
+
+#### Platform Support
+
+- Linux: x86_64, aarch64
+- macOS: aarch64
+- Windows: x86_64
+
+#### Configuration
+
+- Licensing mode configuration via `--@rules_coco//:license_source`
+- Version selection via `--@rules_coco//:version` flag
+- Verification backend selection via `--@rules_coco//:verification_backend`
+
+[Unreleased]: https://github.com/cocotec/rules_coco/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/cocotec/rules_coco/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ coco_package(
 )
 ```
 
+To enable type checking as part of the build, add `typecheck = True`:
+
+```starlark
+coco_package(
+    name = "my_package",
+    srcs = glob(["*.coco"]),
+    manifest = "Coco.toml",
+    typecheck = True,  # Validates types before code generation
+)
+```
+
+When enabled, any target depending on this package (such as `coco_generate`) will wait for typecheck to pass.
+
 ### Generating Code
 
 To generate C++ code:

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -2,30 +2,6 @@
 
 Public API for Coco package rules and code generation.
 
-<a id="coco_package"></a>
-
-## coco_package
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_package")
-
-coco_package(<a href="#coco_package-name">name</a>, <a href="#coco_package-deps">deps</a>, <a href="#coco_package-srcs">srcs</a>, <a href="#coco_package-package">package</a>, <a href="#coco_package-test_srcs">test_srcs</a>)
-</pre>
-
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="coco_package-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="coco_package-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="coco_package-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="coco_package-package"></a>package |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="coco_package-test_srcs"></a>test_srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-
-
 <a id="with_popili_version"></a>
 
 ## with_popili_version
@@ -111,6 +87,27 @@ coco_generate(<a href="#coco_generate-name">name</a>, <a href="#coco_generate-kw
 | :------------- | :------------- | :------------- |
 | <a id="coco_generate-name"></a>name |  <p align="center"> - </p>   |  none |
 | <a id="coco_generate-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="coco_package"></a>
+
+## coco_package
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_package")
+
+coco_package(<a href="#coco_package-name">name</a>, <a href="#coco_package-kwargs">**kwargs</a>)
+</pre>
+
+Define a Coco package from Coco.toml and .coco source files.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="coco_package-name"></a>name |  Name of the package target   |  none |
+| <a id="coco_package-kwargs"></a>kwargs |  Additional arguments passed to the underlying rule   |  none |
 
 
 <a id="coco_test_outputs_name"></a>

--- a/test/simple/BUILD
+++ b/test/simple/BUILD
@@ -21,6 +21,7 @@ coco_package(
     name = "base",
     srcs = glob(["src/**/*.coco"]),
     package = "Coco.toml",
+    typecheck = True,
 )
 
 coco_verify_test(


### PR DESCRIPTION
This is optional as it's normally done as part of codegen, but it's nice to have the option to do it separately.