### PR TITLE
feat(rules): add support for coco workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Coco workspaces are now supported via the new `coco_workspace` rule and `workspace` attribute on `coco_package`.
+
 ## [0.2.0] - 2026/04/20
 
 ### Added

--- a/coco/defs.bzl
+++ b/coco/defs.bzl
@@ -16,10 +16,12 @@
 
 load(
     "//coco/private:coco.bzl",
+    _CocoWorkspaceInfo = "CocoWorkspaceInfo",
     _coco_generate = "coco_generate",
     _coco_package = "coco_package",
     _coco_test_outputs_name = "coco_test_outputs_name",
     _coco_verify_test = "coco_verify_test",
+    _coco_workspace = "coco_workspace",
     _with_popili_version = "with_popili_version",
 )
 load(
@@ -39,6 +41,10 @@ load(
 )
 
 coco_package = _coco_package
+
+coco_workspace = _coco_workspace
+
+CocoWorkspaceInfo = _CocoWorkspaceInfo
 
 coco_verify_test = _coco_verify_test
 

--- a/coco/private/coco.bzl
+++ b/coco/private/coco.bzl
@@ -31,6 +31,14 @@ CocoPackageInfo = provider(
         "srcs": "All .coco files that are sources of this package or any of its transitive dependencies",
         "test_srcs": "All .coco files that are test_sources of this package or any of its transitive dependencies",
         "typecheck_marker": "Marker file indicating typecheck passed (or None if typecheck disabled)",
+        "workspace_files": "Coco.toml files for any enclosing workspaces of this package or its transitive dependencies",
+    },
+)
+
+CocoWorkspaceInfo = provider(
+    doc = "Information about a Coco workspace root whose shared settings flow down to member packages",
+    fields = {
+        "files": "Coco.toml files a member must ship: this workspace's root manifest plus any parent workspaces",
     },
 )
 
@@ -283,6 +291,7 @@ def _coco_runfiles(ctx, package, is_test):
         direct.append(package[CocoPackageInfo].package_file)
         transitive.append(package[CocoPackageInfo].srcs)
         transitive.append(package[CocoPackageInfo].dep_package_files)
+        transitive.append(package[CocoPackageInfo].workspace_files)
 
         # Include typecheck marker if present to ensure codegen waits for typecheck
         if package[CocoPackageInfo].typecheck_marker:
@@ -422,16 +431,19 @@ def _run_typecheck(ctx, package, srcs, test_srcs):
         tools = [ctx.toolchains[COCO_TOOLCHAIN_TYPE].coco, script],
         mnemonic = "CocoTypecheck",
         progress_message = "Typechecking %s" % ctx.label.name,
-        inputs = depset(direct = inputs_direct, transitive = [srcs, test_srcs, package.dep_package_files]),
+        inputs = depset(direct = inputs_direct, transitive = [srcs, test_srcs, package.dep_package_files, package.workspace_files]),
         outputs = [marker],
         arguments = [],
     )
 
     return marker
 
+def _require_coco_toml(file, attr):
+    if file.basename != "Coco.toml":
+        fail("%s must point to a file called exactly 'Coco.toml'" % attr.capitalize(), attr = attr)
+
 def _coco_package_impl(ctx):
-    if ctx.file.package.basename != "Coco.toml":
-        fail("Package must point to a file called exactly 'Coco.toml'", attr = "package")
+    _require_coco_toml(ctx.file.package, "package")
     package_file = ctx.file.package
     dep_package_files = depset(
         direct = [dep[CocoPackageInfo].package_file for dep in ctx.attr.deps],
@@ -446,12 +458,19 @@ def _coco_package_impl(ctx):
         transitive = [dep[CocoPackageInfo].test_srcs for dep in ctx.attr.deps],
     )
 
+    # Workspace Coco.toml files for this package and its deps, so popili can resolve inherited settings
+    workspace_transitive = [dep[CocoPackageInfo].workspace_files for dep in ctx.attr.deps]
+    if ctx.attr.workspace:
+        workspace_transitive.append(ctx.attr.workspace[CocoWorkspaceInfo].files)
+    workspace_files = depset(transitive = workspace_transitive)
+
     # Conditionally run typecheck
     typecheck_marker = None
     if ctx.attr.typecheck:
         package_struct = struct(
             package_file = package_file,
             dep_package_files = dep_package_files,
+            workspace_files = workspace_files,
         )
         typecheck_marker = _run_typecheck(ctx, package_struct, srcs, test_srcs)
 
@@ -470,8 +489,9 @@ def _coco_package_impl(ctx):
             srcs = srcs,
             test_srcs = test_srcs,
             typecheck_marker = typecheck_marker,
+            workspace_files = workspace_files,
         ),
-        DefaultInfo(files = depset(direct = default_files_direct, transitive = [srcs, test_srcs, dep_package_files])),
+        DefaultInfo(files = depset(direct = default_files_direct, transitive = [srcs, test_srcs, dep_package_files, workspace_files])),
     ]
 
 _coco_package = rule(
@@ -498,13 +518,16 @@ _coco_package = rule(
         "typecheck": attr.bool(
             default = False,
         ),
+        "workspace": attr.label(
+            providers = [CocoWorkspaceInfo],
+        ),
     }.items()),
     toolchains = [
         COCO_TOOLCHAIN_TYPE,
     ],
 )
 
-def coco_package(name, package, srcs, deps = [], test_srcs = [], typecheck = False, **kwargs):
+def coco_package(name, package, srcs, deps = [], test_srcs = [], typecheck = False, workspace = None, **kwargs):
     """Define a Coco package from Coco.toml and .coco source files.
 
     Args:
@@ -515,6 +538,7 @@ def coco_package(name, package, srcs, deps = [], test_srcs = [], typecheck = Fal
         test_srcs: List of .coco test source files
         typecheck: Run typecheck validation during package creation. When enabled,
                    the build will fail if typecheck errors are found.
+        workspace: Optional coco_workspace whose Coco.toml settings this package inherits
         **kwargs: Additional Bazel arguments (e.g., visibility, tags)
     """
     _coco_package(
@@ -524,10 +548,61 @@ def coco_package(name, package, srcs, deps = [], test_srcs = [], typecheck = Fal
         deps = deps,
         test_srcs = test_srcs,
         typecheck = typecheck,
+        workspace = workspace,
         is_windows = select({
             "@platforms//os:windows": True,
             "//conditions:default": False,
         }),
+        **kwargs
+    )
+
+def _coco_workspace_impl(ctx):
+    _require_coco_toml(ctx.file.workspace, "workspace")
+
+    parent_transitive = []
+    if ctx.attr.parent:
+        parent_transitive.append(ctx.attr.parent[CocoWorkspaceInfo].files)
+    files = depset(direct = [ctx.file.workspace], transitive = parent_transitive)
+
+    return [
+        CocoWorkspaceInfo(
+            files = files,
+        ),
+        DefaultInfo(files = files),
+    ]
+
+_coco_workspace = rule(
+    implementation = _coco_workspace_impl,
+    attrs = {
+        "parent": attr.label(
+            providers = [CocoWorkspaceInfo],
+            doc = "An enclosing coco_workspace, when this workspace is nested inside another",
+        ),
+        "workspace": attr.label(
+            mandatory = True,
+            allow_single_file = [".toml"],
+            doc = "Label pointing to the workspace's root Coco.toml (must contain a [workspace] section)",
+        ),
+    },
+    doc = "Declares a Coco workspace root whose shared settings flow down to member coco_package targets.",
+)
+
+def coco_workspace(name, workspace, parent = None, **kwargs):
+    """Declares a Coco workspace root.
+
+    A workspace's Coco.toml carries shared settings that popili applies to member
+    packages. Reference this target from a coco_package's `workspace` attribute.
+
+    Args:
+        name: Name of the workspace target
+        workspace: Label pointing to the workspace's root Coco.toml
+        parent: Optional parent coco_workspace target, for nested workspaces
+        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
+    """
+    _coco_workspace(
+        name = name,
+        workspace = workspace,
+        parent = parent,
         **kwargs
     )
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -36,6 +36,25 @@ Example:
 | <a id="with_popili_version-version"></a>version |  The popili version to use (e.g., '1.5.0', '1.4.7')   | String | required |  |
 
 
+<a id="CocoWorkspaceInfo"></a>
+
+## CocoWorkspaceInfo
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "CocoWorkspaceInfo")
+
+CocoWorkspaceInfo(<a href="#CocoWorkspaceInfo-files">files</a>)
+</pre>
+
+Information about a Coco workspace root whose shared settings flow down to member packages
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="CocoWorkspaceInfo-files"></a>files |  Coco.toml files a member must ship: this workspace's root manifest plus any parent workspaces    |
+
+
 <a id="coco_architecture_diagram"></a>
 
 ## coco_architecture_diagram
@@ -194,7 +213,7 @@ the settings in your Coco.toml file under the corresponding generator section
 <pre>
 load("@rules_coco//coco:defs.bzl", "coco_package")
 
-coco_package(<a href="#coco_package-name">name</a>, <a href="#coco_package-package">package</a>, <a href="#coco_package-srcs">srcs</a>, <a href="#coco_package-deps">deps</a>, <a href="#coco_package-test_srcs">test_srcs</a>, <a href="#coco_package-typecheck">typecheck</a>, <a href="#coco_package-kwargs">**kwargs</a>)
+coco_package(<a href="#coco_package-name">name</a>, <a href="#coco_package-package">package</a>, <a href="#coco_package-srcs">srcs</a>, <a href="#coco_package-deps">deps</a>, <a href="#coco_package-test_srcs">test_srcs</a>, <a href="#coco_package-typecheck">typecheck</a>, <a href="#coco_package-workspace">workspace</a>, <a href="#coco_package-kwargs">**kwargs</a>)
 </pre>
 
 Define a Coco package from Coco.toml and .coco source files.
@@ -210,6 +229,7 @@ Define a Coco package from Coco.toml and .coco source files.
 | <a id="coco_package-deps"></a>deps |  List of other coco_package targets this package depends on   |  `[]` |
 | <a id="coco_package-test_srcs"></a>test_srcs |  List of .coco test source files   |  `[]` |
 | <a id="coco_package-typecheck"></a>typecheck |  Run typecheck validation during package creation. When enabled, the build will fail if typecheck errors are found.   |  `False` |
+| <a id="coco_package-workspace"></a>workspace |  Optional coco_workspace whose Coco.toml settings this package inherits   |  `None` |
 | <a id="coco_package-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
 
 
@@ -284,6 +304,33 @@ verifying the Coco code.
 | <a id="coco_verify_test-name"></a>name |  Name of the test target   |  none |
 | <a id="coco_verify_test-package"></a>package |  The coco_package target to verify   |  none |
 | <a id="coco_verify_test-kwargs"></a>kwargs |  Additional Bazel test arguments (e.g., size, timeout, tags, visibility)   |  none |
+
+
+<a id="coco_workspace"></a>
+
+## coco_workspace
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_workspace")
+
+coco_workspace(<a href="#coco_workspace-name">name</a>, <a href="#coco_workspace-workspace">workspace</a>, <a href="#coco_workspace-parent">parent</a>, <a href="#coco_workspace-kwargs">**kwargs</a>)
+</pre>
+
+Declares a Coco workspace root.
+
+A workspace's Coco.toml carries shared settings that popili applies to member
+packages. Reference this target from a coco_package's `workspace` attribute.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="coco_workspace-name"></a>name |  Name of the workspace target   |  none |
+| <a id="coco_workspace-workspace"></a>workspace |  Label pointing to the workspace's root Coco.toml   |  none |
+| <a id="coco_workspace-parent"></a>parent |  Optional parent coco_workspace target, for nested workspaces   |  `None` |
+| <a id="coco_workspace-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
 
 
 <a id="counterexample_options"></a>

--- a/test/workspace_basic/BUILD
+++ b/test/workspace_basic/BUILD
@@ -1,0 +1,114 @@
+# Copyright 2026 Cocotec Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_coco//coco:cc.bzl", "coco_cc_library")
+load("@rules_coco//coco:defs.bzl", "coco_generate", "coco_package", "coco_verify_test", "coco_workspace")
+
+# Basic workspace: shared [language]/[generator] in the root Coco.toml flow down
+# to members (base -> middle -> app), which declare only [package]/[dependencies].
+coco_workspace(
+    name = "workspace",
+    workspace = "Coco.toml",
+)
+
+coco_package(
+    name = "base",
+    srcs = glob(["base/src/**/*.coco"]),
+    package = "base/Coco.toml",
+    workspace = ":workspace",
+)
+
+coco_verify_test(
+    name = "base_verify",
+    package = ":base",
+)
+
+coco_generate(
+    name = "base_cpp",
+    language = "cpp",
+    mocks = True,
+    package = ":base",
+)
+
+coco_cc_library(
+    name = "base_cc",
+    generated_package = ":base_cpp",
+    includes = ["base/src"],
+)
+
+coco_package(
+    name = "middle",
+    srcs = glob(["middle/src/**/*.coco"]),
+    package = "middle/Coco.toml",
+    workspace = ":workspace",
+    deps = [":base"],
+)
+
+coco_verify_test(
+    name = "middle_verify",
+    package = ":middle",
+)
+
+coco_generate(
+    name = "middle_cpp",
+    language = "cpp",
+    package = ":middle",
+)
+
+coco_cc_library(
+    name = "middle_cc",
+    generated_package = ":middle_cpp",
+    includes = ["middle/src"],
+    deps = [":base_cc"],
+)
+
+# typecheck = True: app omits [language], so this checks the typecheck action
+# also receives the workspace Coco.toml (needed for the standard).
+coco_package(
+    name = "app",
+    srcs = glob(["app/src/**/*.coco"]),
+    package = "app/Coco.toml",
+    typecheck = True,
+    workspace = ":workspace",
+    deps = [":middle"],
+)
+
+coco_verify_test(
+    name = "app_verify",
+    package = ":app",
+)
+
+coco_generate(
+    name = "app_cpp",
+    language = "cpp",
+    package = ":app",
+)
+
+coco_cc_library(
+    name = "app_cc",
+    generated_package = ":app_cpp",
+    deps = [":middle_cc"],
+)
+
+cc_test(
+    name = "unit",
+    srcs = ["app/test/app_test.cc"],
+    deps = [
+        ":app_cc",
+        ":base_cc",
+        ":middle_cc",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/workspace_basic/Coco.toml
+++ b/test/workspace_basic/Coco.toml
@@ -1,0 +1,16 @@
+[workspace]
+members = [
+  "base",
+  "middle",
+  "app",
+]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[generator.cpp]
+generateMocks = "GMock"

--- a/test/workspace_basic/app/Coco.toml
+++ b/test/workspace_basic/app/Coco.toml
@@ -1,0 +1,6 @@
+[package]
+name = "app"
+sources = ["src"]
+
+[dependencies]
+middle = "*"

--- a/test/workspace_basic/app/src/IApp.coco
+++ b/test/workspace_basic/app/src/IApp.coco
@@ -1,0 +1,6 @@
+import unqualified IMiddle
+
+@runtime(.MultiThreaded)
+external component App {
+  val middle : Provided<IMiddle>
+}

--- a/test/workspace_basic/app/test/app_test.cc
+++ b/test/workspace_basic/app/test/app_test.cc
@@ -1,0 +1,48 @@
+#include "gtest/gtest.h"
+
+#include "test/workspace_basic/app/src/IApp.h"
+#include "test/workspace_basic/middle/src/IMiddle.h"
+#include "test/workspace_basic/base/src/IBase.h"
+
+TEST(WorkspaceBasicTest, TestEnumFromBasePackage) {
+  Status status = Status::OK;
+  EXPECT_EQ(status, Status::OK);
+
+  status = Status::ERROR;
+  EXPECT_EQ(status, Status::ERROR);
+}
+
+TEST(WorkspaceBasicTest, TestConfigStructFromBasePackage) {
+  Config config(100, Status::OK);
+
+  EXPECT_EQ(config.timeout, 100);
+  EXPECT_EQ(config.status, Status::OK);
+}
+
+TEST(WorkspaceBasicTest, TestPriorityEnumFromMiddlePackage) {
+  Priority priority = Priority::MEDIUM;
+  EXPECT_EQ(priority, Priority::MEDIUM);
+}
+
+TEST(WorkspaceBasicTest, TestTaskStructFromMiddlePackage) {
+  Config config(200, Status::ERROR);
+  Task task(config, Priority::HIGH);
+
+  EXPECT_EQ(task.config.timeout, 200);
+  EXPECT_EQ(task.config.status, Status::ERROR);
+  EXPECT_EQ(task.priority, Priority::HIGH);
+}
+
+TEST(WorkspaceBasicTest, TestThreeLevelDependencyChain) {
+  Config baseConfig(150, Status::OK);
+  Task middleTask(baseConfig, Priority::MEDIUM);
+
+  EXPECT_EQ(middleTask.config.timeout, 150);
+  EXPECT_EQ(middleTask.config.status, Status::OK);
+  EXPECT_EQ(middleTask.priority, Priority::MEDIUM);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/workspace_basic/base/Coco.toml
+++ b/test/workspace_basic/base/Coco.toml
@@ -1,0 +1,3 @@
+[package]
+name = "base"
+sources = ["src"]

--- a/test/workspace_basic/base/src/IBase.coco
+++ b/test/workspace_basic/base/src/IBase.coco
@@ -1,0 +1,28 @@
+enum Status {
+  case OK
+  case ERROR
+  case PENDING
+}
+
+struct Config {
+  var timeout : Int32
+  var status : Status
+}
+
+// Uses a .Coco1_2 feature, so this builds only if the workspace's standard reaches it.
+struct Gated {
+  @available(.Coco1_2)
+  var value : Int32
+}
+
+port IBase {
+  function getConfig() : Config
+  function getStatus() : Status
+  function getGated() : Int32
+
+  machine {
+    getConfig() = Config{ timeout = 0, status = Status.OK }
+    getStatus() = Status.OK
+    getGated() = Gated{ value = 42 }.value
+  }
+}

--- a/test/workspace_basic/middle/Coco.toml
+++ b/test/workspace_basic/middle/Coco.toml
@@ -1,0 +1,6 @@
+[package]
+name = "middle"
+sources = ["src"]
+
+[dependencies]
+base = "*"

--- a/test/workspace_basic/middle/src/IMiddle.coco
+++ b/test/workspace_basic/middle/src/IMiddle.coco
@@ -1,0 +1,22 @@
+import unqualified IBase
+
+enum Priority {
+  case LOW
+  case MEDIUM
+  case HIGH
+}
+
+struct Task {
+  var config : Config
+  var priority : Priority
+}
+
+port IMiddle {
+  function getDefaultPriority() : Priority
+  function getDefaultStatus() : Status
+
+  machine {
+    getDefaultPriority() = Priority.MEDIUM
+    getDefaultStatus() = Status.OK
+  }
+}

--- a/test/workspace_cross/BUILD
+++ b/test/workspace_cross/BUILD
@@ -1,0 +1,93 @@
+# Copyright 2026 Cocotec Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_coco//coco:cc.bzl", "coco_cc_library")
+load("@rules_coco//coco:defs.bzl", "coco_generate", "coco_package", "coco_verify_test", "coco_workspace")
+
+# Cross-workspace dependency: `lib` is in workspace `ws_lib`, `app` is in a
+# DIFFERENT workspace `ws_app` and depends on it. Exercises dep-propagation:
+# resolving `app` needs lib's ws_lib Coco.toml, which reaches app's action only
+# because coco_package unions each dep's workspace_files into its own.
+
+coco_workspace(
+    name = "ws_lib",
+    workspace = "ws_lib/Coco.toml",
+)
+
+coco_workspace(
+    name = "ws_app",
+    workspace = "ws_app/Coco.toml",
+)
+
+coco_package(
+    name = "lib",
+    srcs = glob(["lib/src/**/*.coco"]),
+    package = "lib/Coco.toml",
+    workspace = ":ws_lib",
+)
+
+coco_package(
+    name = "app",
+    srcs = glob(["app/src/**/*.coco"]),
+    package = "app/Coco.toml",
+    workspace = ":ws_app",
+    deps = [":lib"],
+)
+
+coco_verify_test(
+    name = "lib_verify",
+    package = ":lib",
+)
+
+coco_verify_test(
+    name = "app_verify",
+    package = ":app",
+)
+
+coco_generate(
+    name = "lib_cpp",
+    language = "cpp",
+    mocks = True,
+    package = ":lib",
+)
+
+coco_generate(
+    name = "app_cpp",
+    language = "cpp",
+    package = ":app",
+)
+
+coco_cc_library(
+    name = "lib_cc",
+    generated_package = ":lib_cpp",
+    includes = ["lib/src"],
+)
+
+coco_cc_library(
+    name = "app_cc",
+    generated_package = ":app_cpp",
+    includes = ["app/src"],
+    deps = [":lib_cc"],
+)
+
+cc_test(
+    name = "unit",
+    srcs = ["app_test.cc"],
+    deps = [
+        ":app_cc",
+        ":lib_cc",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/workspace_cross/app/Coco.toml
+++ b/test/workspace_cross/app/Coco.toml
@@ -1,0 +1,8 @@
+[package]
+name = "app"
+sources = ["src"]
+# Inherits from the ws_app workspace root — a different workspace than lib's.
+workspace = "../ws_app"
+
+[dependencies]
+lib = "*"

--- a/test/workspace_cross/app/src/IApp.coco
+++ b/test/workspace_cross/app/src/IApp.coco
@@ -1,0 +1,14 @@
+import unqualified ILib
+
+struct AppData {
+  var config : Config
+  var count : Int32
+}
+
+port IApp {
+  function getData() : AppData
+
+  machine {
+    getData() = AppData{ config = Config{ timeout = 0, status = Status.OK }, count = 1 }
+  }
+}

--- a/test/workspace_cross/app_test.cc
+++ b/test/workspace_cross/app_test.cc
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+
+#include "test/workspace_cross/app/src/IApp.h"
+#include "test/workspace_cross/lib/src/ILib.h"
+
+TEST(WorkspaceCrossTest, ConfigFromLibWorkspace) {
+  Config config(100, Status::OK);
+
+  EXPECT_EQ(config.timeout, 100);
+  EXPECT_EQ(config.status, Status::OK);
+}
+
+TEST(WorkspaceCrossTest, AppDataReferencesLibType) {
+  Config config(50, Status::ERROR);
+  AppData data(config, 7);
+
+  EXPECT_EQ(data.config.timeout, 50);
+  EXPECT_EQ(data.config.status, Status::ERROR);
+  EXPECT_EQ(data.count, 7);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/workspace_cross/lib/Coco.toml
+++ b/test/workspace_cross/lib/Coco.toml
@@ -1,0 +1,5 @@
+[package]
+name = "lib"
+sources = ["src"]
+# Inherits [language]/[generator] from the ws_lib workspace root.
+workspace = "../ws_lib"

--- a/test/workspace_cross/lib/src/ILib.coco
+++ b/test/workspace_cross/lib/src/ILib.coco
@@ -1,0 +1,26 @@
+enum Status {
+  case OK
+  case ERROR
+  case PENDING
+}
+
+struct Config {
+  var timeout : Int32
+  var status : Status
+}
+
+// Uses a .Coco1_2 feature, so this builds only if the workspace's standard reaches it.
+struct Gated {
+  @available(.Coco1_2)
+  var value : Int32
+}
+
+port ILib {
+  function getConfig() : Config
+  function getGated() : Int32
+
+  machine {
+    getConfig() = Config{ timeout = 0, status = Status.OK }
+    getGated() = Gated{ value = 42 }.value
+  }
+}

--- a/test/workspace_cross/ws_app/Coco.toml
+++ b/test/workspace_cross/ws_app/Coco.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+  "../app",
+]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[generator.cpp]
+generateMocks = "GMock"

--- a/test/workspace_cross/ws_lib/Coco.toml
+++ b/test/workspace_cross/ws_lib/Coco.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+  "../lib",
+]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[generator.cpp]
+generateMocks = "GMock"

--- a/test/workspace_explicit/BUILD
+++ b/test/workspace_explicit/BUILD
@@ -1,0 +1,62 @@
+# Copyright 2026 Cocotec Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_coco//coco:cc.bzl", "coco_cc_library")
+load("@rules_coco//coco:defs.bzl", "coco_generate", "coco_package", "coco_verify_test", "coco_workspace")
+
+# Explicit, non-child workspace: `pkg` is a SIBLING of root `ws`, wired by
+# relative path (pkg: `workspace = "../ws"`, ws: `members = ["../pkg"]`) — a
+# workspace need not be a filesystem ancestor of its members. typecheck = True
+# also covers the typecheck action's workspace inputs.
+
+coco_workspace(
+    name = "ws",
+    workspace = "ws/Coco.toml",
+)
+
+coco_package(
+    name = "pkg",
+    srcs = glob(["pkg/src/**/*.coco"]),
+    package = "pkg/Coco.toml",
+    typecheck = True,
+    workspace = ":ws",
+)
+
+coco_verify_test(
+    name = "pkg_verify",
+    package = ":pkg",
+)
+
+coco_generate(
+    name = "pkg_cpp",
+    language = "cpp",
+    mocks = True,
+    package = ":pkg",
+)
+
+coco_cc_library(
+    name = "pkg_cc",
+    generated_package = ":pkg_cpp",
+    includes = ["pkg/src"],
+)
+
+cc_test(
+    name = "unit",
+    srcs = ["pkg_test.cc"],
+    deps = [
+        ":pkg_cc",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/workspace_explicit/pkg/Coco.toml
+++ b/test/workspace_explicit/pkg/Coco.toml
@@ -1,0 +1,5 @@
+[package]
+name = "pkg"
+sources = ["src"]
+# No [language]/[generator] here — inherited from the workspace root.
+workspace = "../ws"

--- a/test/workspace_explicit/pkg/src/IPkg.coco
+++ b/test/workspace_explicit/pkg/src/IPkg.coco
@@ -1,0 +1,26 @@
+enum Colour {
+  case RED
+  case GREEN
+  case BLUE
+}
+
+struct Pixel {
+  var colour : Colour
+  var brightness : Int32
+}
+
+// Uses a .Coco1_2 feature, so this builds only if the workspace's standard reaches it.
+struct Gated {
+  @available(.Coco1_2)
+  var value : Int32
+}
+
+port IPkg {
+  function getDefaultPixel() : Pixel
+  function getGated() : Int32
+
+  machine {
+    getDefaultPixel() = Pixel{ colour = Colour.RED, brightness = 128 }
+    getGated() = Gated{ value = 42 }.value
+  }
+}

--- a/test/workspace_explicit/pkg_test.cc
+++ b/test/workspace_explicit/pkg_test.cc
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+
+#include "test/workspace_explicit/pkg/src/IPkg.h"
+
+TEST(WorkspaceExplicitTest, PixelFromNonChildWorkspaceMember) {
+  Pixel pixel(Colour::GREEN, 200);
+
+  EXPECT_EQ(pixel.colour, Colour::GREEN);
+  EXPECT_EQ(pixel.brightness, 200);
+}
+
+TEST(WorkspaceExplicitTest, DefaultPixelValues) {
+  Pixel pixel(Colour::RED, 128);
+
+  EXPECT_EQ(pixel.colour, Colour::RED);
+  EXPECT_EQ(pixel.brightness, 128);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/workspace_explicit/ws/Coco.toml
+++ b/test/workspace_explicit/ws/Coco.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+  "../pkg",
+]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[generator.cpp]
+generateMocks = "GMock"

--- a/test/workspace_nested/BUILD
+++ b/test/workspace_nested/BUILD
@@ -1,0 +1,66 @@
+# Copyright 2026 Cocotec Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_coco//coco:cc.bzl", "coco_cc_library")
+load("@rules_coco//coco:defs.bzl", "coco_generate", "coco_package", "coco_verify_test", "coco_workspace")
+
+# Nested workspaces (outer -> inner -> pkg): the outer's [language] standard and
+# the inner's [generator] settings both flow down to pkg. pkg uses a .Coco1_2
+# feature, so it builds only if the outer's standard reaches it through inner.
+
+coco_workspace(
+    name = "outer",
+    workspace = "Coco.toml",
+)
+
+coco_workspace(
+    name = "inner",
+    parent = ":outer",
+    workspace = "inner/Coco.toml",
+)
+
+coco_package(
+    name = "pkg",
+    srcs = glob(["inner/pkg/src/**/*.coco"]),
+    package = "inner/pkg/Coco.toml",
+    workspace = ":inner",
+)
+
+coco_verify_test(
+    name = "pkg_verify",
+    package = ":pkg",
+)
+
+coco_generate(
+    name = "pkg_cpp",
+    language = "cpp",
+    mocks = True,
+    package = ":pkg",
+)
+
+coco_cc_library(
+    name = "pkg_cc",
+    generated_package = ":pkg_cpp",
+    includes = ["inner/pkg/src"],
+)
+
+cc_test(
+    name = "unit",
+    srcs = ["pkg_test.cc"],
+    deps = [
+        ":pkg_cc",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/workspace_nested/Coco.toml
+++ b/test/workspace_nested/Coco.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = [
+  "inner",
+]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"

--- a/test/workspace_nested/inner/Coco.toml
+++ b/test/workspace_nested/inner/Coco.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [
+  "pkg",
+]
+
+# No [language] here: pkg inherits the Coco standard from the outer workspace.
+[generator.cpp]
+generateMocks = "GMock"

--- a/test/workspace_nested/inner/pkg/Coco.toml
+++ b/test/workspace_nested/inner/pkg/Coco.toml
@@ -1,0 +1,3 @@
+[package]
+name = "pkg"
+sources = ["src"]

--- a/test/workspace_nested/inner/pkg/src/IPkg.coco
+++ b/test/workspace_nested/inner/pkg/src/IPkg.coco
@@ -1,0 +1,26 @@
+enum Colour {
+  case RED
+  case GREEN
+  case BLUE
+}
+
+struct Pixel {
+  var colour : Colour
+  var brightness : Int32
+}
+
+// Uses a .Coco1_2 feature, so this builds only if the workspace's standard reaches it.
+struct Gated {
+  @available(.Coco1_2)
+  var value : Int32
+}
+
+port IPkg {
+  function getDefaultPixel() : Pixel
+  function getGated() : Int32
+
+  machine {
+    getDefaultPixel() = Pixel{ colour = Colour.RED, brightness = 128 }
+    getGated() = Gated{ value = 42 }.value
+  }
+}

--- a/test/workspace_nested/pkg_test.cc
+++ b/test/workspace_nested/pkg_test.cc
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+
+#include "test/workspace_nested/inner/pkg/src/IPkg.h"
+
+TEST(WorkspaceNestedTest, PixelStructFromNestedWorkspacePackage) {
+  Pixel pixel(Colour::GREEN, 200);
+
+  EXPECT_EQ(pixel.colour, Colour::GREEN);
+  EXPECT_EQ(pixel.brightness, 200);
+}
+
+TEST(WorkspaceNestedTest, DefaultPixelValues) {
+  Pixel pixel(Colour::RED, 128);
+
+  EXPECT_EQ(pixel.colour, Colour::RED);
+  EXPECT_EQ(pixel.brightness, 128);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
A coco_workspace target carries a workspace's root Coco.toml; setting the new `workspace` attribute on a coco_package ships that manifest (plus any parent workspaces) as an action input so popili resolves the language, generator, and other settings that members inherit from it. Nested workspaces are supported via the `parent` attribute, and members need not be nested under the workspace directory.