### PR TITLE
fix(rules): resolve test --package/--import-path in the runfiles tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Coco workspaces are now supported via the new `coco_workspace` rule and `workspace` attribute on `coco_package`.
 
+### Fixed
+
+- `coco_verify_test` and `coco_fmt_test` now resolve `--package`/`--import-path` against the runfiles tree, so a
+  package that depends on a `coco_package` in another Bazel repository verifies correctly, fixing errors such as
+  `invalid import path; external/<repo> is not a directory`.
+
 ## [0.2.0] - 2026/04/20
 
 ### Added

--- a/coco/private/coco.bzl
+++ b/coco/private/coco.bzl
@@ -176,6 +176,11 @@ with_popili_version = rule(
 def _runtime_path(file, is_test):
     return file.short_path if is_test else file.path
 
+def _runtime_dirname(file, is_test):
+    # File.dirname, but via the runtime path (short_path for tests) so
+    # external-repo deps resolve in the runfiles tree; "." avoids an empty arg.
+    return paths.dirname(_runtime_path(file, is_test)) or "."
+
 def _coco_startup_args(ctx, package, is_test):
     """Build startup arguments for popili.
 
@@ -222,10 +227,10 @@ def _coco_startup_args(ctx, package, is_test):
             dep_package_files = package[CocoPackageInfo].dep_package_files
         arguments += [
             "--package",
-            package_file.dirname,
+            _runtime_dirname(package_file, is_test),
         ]
         for dep_file in dep_package_files.to_list():
-            arguments += ["--import-path", dep_file.dirname]
+            arguments += ["--import-path", _runtime_dirname(dep_file, is_test)]
     return arguments
 
 def _get_license_source(ctx):

--- a/e2e/external_deps/.bazelrc
+++ b/e2e/external_deps/.bazelrc
@@ -1,0 +1,16 @@
+# For windows we need proper runfiles
+startup --windows_enable_symlinks
+common --enable_runfiles=true
+
+# Enable platform-specific config (build:windows, build:linux, build:macos)
+common --enable_platform_specific_config
+
+common --enable_bzlmod=true
+common:bzlmod --enable_bzlmod=true
+common:workspace --enable_bzlmod=false
+common:workspace --enable_workspace=true
+
+# Windows-specific: Enable conforming preprocessor for proper macro handling
+build:windows --copt=/Zc:preprocessor
+build:windows --host_copt=/Zc:preprocessor
+build:windows --repo_env=BAZEL_SH

--- a/e2e/external_deps/BUILD.bazel
+++ b/e2e/external_deps/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_coco//coco:defs.bzl", "coco_package", "coco_verify_test")
+
+coco_package(
+    name = "app",
+    srcs = glob(["src/**/*.coco"]),
+    package = "Coco.toml",
+    deps = ["@coco_dep//:base"],
+)
+
+# Previously failed: "invalid import path; external/coco_dep+ is not a directory".
+coco_verify_test(
+    name = "app_verify",
+    package = ":app",
+)

--- a/e2e/external_deps/Coco.toml
+++ b/e2e/external_deps/Coco.toml
@@ -1,0 +1,13 @@
+[package]
+name = "app"
+sources = ["src"]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[dependencies]
+base = "*"

--- a/e2e/external_deps/MODULE.bazel
+++ b/e2e/external_deps/MODULE.bazel
@@ -1,0 +1,26 @@
+# Verifies a coco_package whose dependency lives in another Bazel repo
+# (@coco_dep): regression coverage for runfiles-relative import paths.
+
+module(
+    name = "rules_coco_external_deps_test",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_coco", version = "")
+local_path_override(
+    module_name = "rules_coco",
+    path = "../..",
+)
+
+bazel_dep(name = "coco_dep", version = "0.0.0")
+local_path_override(
+    module_name = "coco_dep",
+    path = "dep",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+
+coco = use_extension("@rules_coco//coco:extensions.bzl", "coco")
+coco.toolchain(cc = True)

--- a/e2e/external_deps/WORKSPACE
+++ b/e2e/external_deps/WORKSPACE
@@ -1,0 +1,19 @@
+workspace(name = "rules_coco_external_deps_test")
+
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
+local_repository(
+    name = "rules_coco",
+    path = "../..",
+)
+
+local_repository(
+    name = "coco_dep",
+    path = "dep",
+)
+
+load("@rules_coco//coco:repositories.bzl", "coco_repositories")
+
+coco_repositories(
+    cc = True,
+)

--- a/e2e/external_deps/dep/BUILD.bazel
+++ b/e2e/external_deps/dep/BUILD.bazel
@@ -1,0 +1,10 @@
+# The "external" coco package depended on by the root module's app package.
+
+load("@rules_coco//coco:defs.bzl", "coco_package")
+
+coco_package(
+    name = "base",
+    srcs = glob(["src/**/*.coco"]),
+    package = "Coco.toml",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/external_deps/dep/Coco.toml
+++ b/e2e/external_deps/dep/Coco.toml
@@ -1,0 +1,10 @@
+[package]
+name = "base"
+sources = ["src"]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"

--- a/e2e/external_deps/dep/MODULE.bazel
+++ b/e2e/external_deps/dep/MODULE.bazel
@@ -1,0 +1,12 @@
+# "External" module hosting a coco_package depended on by the root module.
+
+module(
+    name = "coco_dep",
+    version = "0.0.0",
+)
+
+# version ignored: the root module's local_path_override supplies rules_coco.
+bazel_dep(name = "rules_coco", version = "")
+
+# coco_package expands to a select() on @platforms//os:windows.
+bazel_dep(name = "platforms", version = "1.0.0")

--- a/e2e/external_deps/dep/WORKSPACE
+++ b/e2e/external_deps/dep/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "coco_dep")

--- a/e2e/external_deps/dep/src/IBase.coco
+++ b/e2e/external_deps/dep/src/IBase.coco
@@ -1,0 +1,20 @@
+enum Status {
+  case OK
+  case ERROR
+  case PENDING
+}
+
+struct Config {
+  var timeout : Int32
+  var status : Status
+}
+
+port IBase {
+  function getConfig() : Config
+  function getStatus() : Status
+
+  machine {
+    getConfig() = Config{ timeout = 0, status = Status.OK }
+    getStatus() = Status.OK
+  }
+}

--- a/e2e/external_deps/src/IApp.coco
+++ b/e2e/external_deps/src/IApp.coco
@@ -1,0 +1,10 @@
+// Imports from the `base` package in the @coco_dep repository.
+import unqualified IBase
+
+port IApp {
+  function getStatus() : Status
+
+  machine {
+    getStatus() = Status.OK
+  }
+}


### PR DESCRIPTION
coco_verify_test and coco_fmt_test run their wrapper in the runfiles tree, but passed --package/--import-path using File.dirname, i.e. the exec-root path. For a dependency in another Bazel repository that is external/<repo>/..., which does not exist at runtime, so popili failed with "invalid import path; external/<repo> is not a directory". Resolve both against the runtime path (short_path for tests), falling back to "." so a root-level package never yields an empty argument.

Add e2e/external_deps covering a coco_verify_test whose package depends on a coco_package in a separate Bazel module.