### PR TITLE
refactor(rules): migrate wrapper macros to Bazel symbolic macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Coco workspaces are now supported via the new `coco_workspace` rule and `workspace` attribute on `coco_package`.
 
+### Changed
+
+- The Coco wrapper macros (`coco_generate`, `coco_package`, `coco_fmt_test`, `coco_workspace`, `coco_verify_test`,
+  `coco_state_diagram`, `coco_architecture_diagram`) are now Bazel symbolic macros, so their attributes and
+  documentation appear in `bazel query` output and the generated reference docs.
+- **Breaking:** the `coco_fmt_test` formatter binary is now named `<name>.format` (previously the test target name
+  with the `_test` suffix stripped). Run it as e.g. `bazel run //pkg:foo_fmt_test.format`.
+
 ### Fixed
 
 - `coco_verify_test` and `coco_fmt_test` now resolve `--package`/`--import-path` against the runfiles tree, so a

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ coco_fmt_test(
 This creates two targets:
 
 - `my_package_fmt_test`: Test that fails if code isn't formatted (`bazel test`)
-- `my_package_fmt`: Binary to format code in-place (`bazel run`)
+- `my_package_fmt_test.format`: Binary to format code in-place (`bazel run`)
 
 ### Diagram Generation
 

--- a/coco/private/coco.bzl
+++ b/coco/private/coco.bzl
@@ -320,6 +320,14 @@ def _run_coco(ctx, package, verb, mnemonic, arguments, outputs):
         arguments = _coco_startup_args(ctx, package, False) + arguments,
     )
 
+WINDOWS_CONSTRAINT_ATTR = attr.label(default = "@platforms//os:windows")
+
+def _is_windows(ctx):
+    """Returns True when the target platform is Windows (via the implicit _windows_constraint attr)."""
+    return ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+
 def _create_coco_wrapper_script(ctx, package, arguments):
     """Creates a platform-specific wrapper script for running Coco commands.
 
@@ -332,7 +340,8 @@ def _create_coco_wrapper_script(ctx, package, arguments):
         The wrapper script file
     """
     coco_path = ctx.toolchains[COCO_TOOLCHAIN_TYPE].coco.short_path
-    if ctx.attr.is_windows:
+    is_windows = _is_windows(ctx)
+    if is_windows:
         coco_path = coco_path.replace("/", "\\")
 
     # Build the full command
@@ -341,7 +350,7 @@ def _create_coco_wrapper_script(ctx, package, arguments):
     env = _coco_env(ctx)
 
     # Create platform-specific wrapper script
-    if ctx.attr.is_windows:
+    if is_windows:
         wrapper_script = ctx.actions.declare_file(ctx.label.name + "-cmd.bat")
         wrapper_lines = []
         for k, v in env.items():
@@ -408,13 +417,14 @@ def _run_typecheck(ctx, package, srcs, test_srcs):
 
     # Create wrapper script that runs typecheck and creates marker on success
     coco_path = ctx.toolchains[COCO_TOOLCHAIN_TYPE].coco.path
-    if ctx.attr.is_windows:
+    is_windows = _is_windows(ctx)
+    if is_windows:
         coco_path = coco_path.replace("/", "\\")
 
     command = " ".join([coco_path] + startup_arguments + typecheck_arguments)
     env = _coco_env(ctx)
 
-    if ctx.attr.is_windows:
+    if is_windows:
         script = ctx.actions.declare_file(ctx.label.name + "_typecheck.bat")
         script_lines = ["@echo off"]
         for k, v in env.items():
@@ -504,62 +514,56 @@ _coco_package = rule(
     attrs = dict(LICENSE_ATTRIBUTES.items() + {
         "deps": attr.label_list(
             providers = [CocoPackageInfo],
-        ),
-        "is_windows": attr.bool(
-            mandatory = True,
+            doc = "Other coco_package targets this package depends on.",
         ),
         "package": attr.label(
             mandatory = True,
             allow_single_file = [".toml"],
+            doc = "Label pointing to the Coco.toml file for this package.",
         ),
         "srcs": attr.label_list(
             allow_files = [".coco"],
             mandatory = True,
+            doc = "The .coco source files for this package.",
         ),
         "test_srcs": attr.label_list(
             allow_files = [".coco"],
             allow_empty = True,
+            doc = "The .coco test source files for this package.",
         ),
         "typecheck": attr.bool(
             default = False,
+            doc = "Run typecheck validation during package creation. When enabled, " +
+                  "the build fails if typecheck errors are found. Disabled by default.",
         ),
         "workspace": attr.label(
             providers = [CocoWorkspaceInfo],
+            doc = "Optional coco_workspace whose Coco.toml settings this package inherits.",
         ),
+        "_windows_constraint": WINDOWS_CONSTRAINT_ATTR,
     }.items()),
     toolchains = [
         COCO_TOOLCHAIN_TYPE,
     ],
 )
 
-def coco_package(name, package, srcs, deps = [], test_srcs = [], typecheck = False, workspace = None, **kwargs):
-    """Define a Coco package from Coco.toml and .coco source files.
-
-    Args:
-        name: Name of the package target
-        package: Label pointing to the Coco.toml file for this package
-        srcs: List of .coco source files for this package
-        deps: List of other coco_package targets this package depends on
-        test_srcs: List of .coco test source files
-        typecheck: Run typecheck validation during package creation. When enabled,
-                   the build will fail if typecheck errors are found.
-        workspace: Optional coco_workspace whose Coco.toml settings this package inherits
-        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
-    """
+def _coco_package_macro_impl(name, visibility, **kwargs):
     _coco_package(
         name = name,
-        package = package,
-        srcs = srcs,
-        deps = deps,
-        test_srcs = test_srcs,
-        typecheck = typecheck,
-        workspace = workspace,
-        is_windows = select({
-            "@platforms//os:windows": True,
-            "//conditions:default": False,
-        }),
+        visibility = visibility,
         **kwargs
     )
+
+coco_package = macro(
+    doc = """Define a Coco package from a Coco.toml and its .coco source files.
+
+A coco_package is the unit the other Coco rules operate on: pass it to
+coco_generate to produce code, to coco_verify_test to verify it, or to
+coco_fmt_test to check formatting. Packages may depend on other packages via
+`deps`, and may inherit shared settings from a coco_workspace via `workspace`.""",
+    inherit_attrs = _coco_package,
+    implementation = _coco_package_macro_impl,
+)
 
 def _coco_workspace_impl(ctx):
     _require_coco_toml(ctx.file.workspace, "workspace")
@@ -592,31 +596,28 @@ _coco_workspace = rule(
     doc = "Declares a Coco workspace root whose shared settings flow down to member coco_package targets.",
 )
 
-def coco_workspace(name, workspace, parent = None, **kwargs):
-    """Declares a Coco workspace root.
-
-    A workspace's Coco.toml carries shared settings that popili applies to member
-    packages. Reference this target from a coco_package's `workspace` attribute.
-
-    Args:
-        name: Name of the workspace target
-        workspace: Label pointing to the workspace's root Coco.toml
-        parent: Optional parent coco_workspace target, for nested workspaces
-        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
-    """
+def _coco_workspace_macro_impl(name, visibility, **kwargs):
     _coco_workspace(
         name = name,
-        workspace = workspace,
-        parent = parent,
+        visibility = visibility,
         **kwargs
     )
+
+coco_workspace = macro(
+    doc = """Declares a Coco workspace root.
+
+A workspace's Coco.toml carries shared settings that popili applies to member
+packages. Reference this target from a coco_package's `workspace` attribute.""",
+    inherit_attrs = _coco_workspace,
+    implementation = _coco_workspace_macro_impl,
+)
 
 def _coco_package_verify(ctx):
     # Build the verify command arguments
     arguments = [
         "verify",
         "--results-junit",
-        "%%XML_OUTPUT_FILE%%" if ctx.attr.is_windows else "$XML_OUTPUT_FILE",
+        "%%XML_OUTPUT_FILE%%" if _is_windows(ctx) else "$XML_OUTPUT_FILE",
     ]
 
     backend = ctx.attr._verification_backend[BuildSettingInfo].value
@@ -634,12 +635,13 @@ def _coco_package_verify(ctx):
 _coco_verify_test = rule(
     implementation = _coco_package_verify,
     attrs = dict(LICENSE_ATTRIBUTES.items() + {
-        "is_windows": attr.bool(mandatory = True),
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
+            doc = "The coco_package target to verify.",
         ),
         "_verification_backend": attr.label(default = Label("//:verification_backend")),
+        "_windows_constraint": WINDOWS_CONSTRAINT_ATTR,
     }.items()),
     test = True,
     toolchains = [
@@ -647,26 +649,21 @@ _coco_verify_test = rule(
     ],
 )
 
-def coco_verify_test(name, package, **kwargs):
-    """Creates a test that runs Coco verification on a package.
-
-    This test executes the `popili verify` command on the specified coco_package,
-    verifying the Coco code.
-
-    Args:
-        name: Name of the test target
-        package: The coco_package target to verify
-        **kwargs: Additional Bazel test arguments (e.g., size, timeout, tags, visibility)
-    """
+def _coco_verify_test_macro_impl(name, visibility, **kwargs):
     _coco_verify_test(
         name = name,
-        package = package,
-        is_windows = select({
-            "@platforms//os:windows": True,
-            "//conditions:default": False,
-        }),
+        visibility = visibility,
         **kwargs
     )
+
+coco_verify_test = macro(
+    doc = """Creates a test that runs Coco verification on a package.
+
+Executes `popili verify` on the specified coco_package, failing the test if
+verification does not pass.""",
+    inherit_attrs = _coco_verify_test,
+    implementation = _coco_verify_test_macro_impl,
+)
 
 def _mangle_name(name, style):
     """Apply name mangling based on the specified style.
@@ -1043,58 +1040,86 @@ _coco_generate = rule(
         # C output path options
         "c_file_name_mangler": attr.string(
             default = "Unaltered",
+            doc = "C file naming style. Must match Coco.toml generator.c.fileNameMangler. " +
+                  "Options: \"Unaltered\" (default), \"LowerCamelCase\", \"UpperCamelCase\", " +
+                  "\"LowerUnderscore\", \"UpperUnderscore\", \"CapsUpperUnderscore\".",
         ),
         "c_flat_file_hierarchy": attr.bool(
             default = False,
+            doc = "Use a flat directory structure for C files. Must match " +
+                  "Coco.toml generator.c.flatFileHierarchy. Disabled by default.",
         ),
         "c_header_file_extension": attr.string(
             default = ".h",
+            doc = "File extension for C headers. Defaults to \".h\".",
         ),
         "c_header_file_prefix": attr.string(
             default = "",
+            doc = "Prefix for C header file names. Empty by default.",
         ),
         "c_implementation_file_extension": attr.string(
             default = ".c",
+            doc = "File extension for C implementation files. Defaults to \".c\".",
         ),
         "c_implementation_file_prefix": attr.string(
             default = "",
+            doc = "Prefix for C implementation file names. Empty by default.",
         ),
         "c_regenerate_packages": attr.label_list(
             providers = [CocoPackageInfo],
             default = [],
+            doc = "Other coco_package targets to regenerate with this target's C generator settings.",
         ),
         # C++ output path options
         "cpp_file_name_mangler": attr.string(
             default = "Unaltered",
+            doc = "C++ file naming style. Must match Coco.toml generator.cpp.fileNameMangler. " +
+                  "Options: \"Unaltered\" (default), \"LowerCamelCase\", \"UpperCamelCase\", " +
+                  "\"LowerUnderscore\", \"UpperUnderscore\", \"CapsUpperUnderscore\".",
         ),
         "cpp_flat_file_hierarchy": attr.bool(
             default = False,
+            doc = "Use a flat directory structure for C++ files. Must match " +
+                  "Coco.toml generator.cpp.flatFileHierarchy. Disabled by default.",
         ),
         "cpp_header_file_extension": attr.string(
             default = ".h",
+            doc = "File extension for C++ headers. Defaults to \".h\".",
         ),
         "cpp_header_file_prefix": attr.string(
             default = "",
+            doc = "Prefix for C++ header file names. Empty by default.",
         ),
         "cpp_implementation_file_extension": attr.string(
             default = ".cc",
+            doc = "File extension for C++ implementation files. Defaults to \".cc\".",
         ),
         "cpp_implementation_file_prefix": attr.string(
             default = "",
+            doc = "Prefix for C++ implementation file names. Empty by default.",
         ),
         "cpp_regenerate_packages": attr.label_list(
             providers = [CocoPackageInfo],
             default = [],
+            doc = "Other coco_package targets to regenerate with this target's C++ generator settings.",
         ),
         "csharp_regenerate_packages": attr.label_list(
             providers = [CocoPackageInfo],
             default = [],
+            doc = "Other coco_package targets to regenerate with this target's C# generator settings.",
         ),
-        "language": attr.string(mandatory = True, values = ["cpp", "c", "csharp"]),
-        "mocks": attr.bool(),
+        "language": attr.string(
+            mandatory = True,
+            values = ["cpp", "c", "csharp"],
+            doc = "Target language for code generation: \"cpp\", \"c\", or \"csharp\".",
+        ),
+        "mocks": attr.bool(
+            doc = "Generate mock implementations for testing. Disabled by default.",
+        ),
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
+            doc = "The coco_package target containing the source files to generate from.",
         ),
     }.items()),
     toolchains = [
@@ -1190,95 +1215,37 @@ _coco_cc_gen = rule(
     },
 )
 
-def coco_generate(
-        name,
-        package,
-        language,
-        mocks = False,
-        c_file_name_mangler = "Unaltered",
-        c_flat_file_hierarchy = False,
-        c_header_file_extension = ".h",
-        c_header_file_prefix = "",
-        c_implementation_file_extension = ".c",
-        c_implementation_file_prefix = "",
-        c_regenerate_packages = [],
-        cpp_file_name_mangler = "Unaltered",
-        cpp_flat_file_hierarchy = False,
-        cpp_header_file_extension = ".h",
-        cpp_header_file_prefix = "",
-        cpp_implementation_file_extension = ".cc",
-        cpp_implementation_file_prefix = "",
-        cpp_regenerate_packages = [],
-        csharp_regenerate_packages = [],
-        **kwargs):
-    """Generate C, C++, or C# code from a Coco package.
-
-    This macro generates code from Coco source files in the specified language.
-    The generated files can then be compiled into libraries or executables using
-    standard build rules (e.g., cc_library for C/C++).
-
-    The generator configuration options (file extensions, prefixes, etc.) must match
-    the settings in your Coco.toml file under the corresponding generator section
-    (e.g., [generator.cpp] for C++, [generator.c] for C).
-
-    Args:
-        name: Name of the code generation target
-        package: The coco_package target containing the source files to generate from
-        language: Target language for code generation: "cpp", "c", or "csharp"
-        mocks: Generate mock implementations for testing (default: False)
-        c_file_name_mangler: C file naming style - must match Coco.toml generator.c.fileNameMangler.
-                             Options: "Unaltered", "LowerCamelCase", "UpperCamelCase",
-                             "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore"
-        c_flat_file_hierarchy: Use flat directory structure for C files - must match
-                               Coco.toml generator.c.flatFileHierarchy
-        c_header_file_extension: File extension for C headers (default: ".h")
-        c_header_file_prefix: Prefix for C header file names (default: "")
-        c_implementation_file_extension: File extension for C implementation files (default: ".c")
-        c_implementation_file_prefix: Prefix for C implementation file names (default: "")
-        c_regenerate_packages: List of other coco_package targets to regenerate with this
-                               target's C generator settings
-        cpp_file_name_mangler: C++ file naming style - must match Coco.toml generator.cpp.fileNameMangler.
-                               Options: "Unaltered", "LowerCamelCase", "UpperCamelCase",
-                               "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore"
-        cpp_flat_file_hierarchy: Use flat directory structure for C++ files - must match
-                                 Coco.toml generator.cpp.flatFileHierarchy
-        cpp_header_file_extension: File extension for C++ headers (default: ".h")
-        cpp_header_file_prefix: Prefix for C++ header file names (default: "")
-        cpp_implementation_file_extension: File extension for C++ implementation files (default: ".cc")
-        cpp_implementation_file_prefix: Prefix for C++ implementation file names (default: "")
-        cpp_regenerate_packages: List of other coco_package targets to regenerate with this
-                                 target's C++ generator settings
-        csharp_regenerate_packages: List of other coco_package targets to regenerate with this
-                                    target's C# generator settings
-        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
-    """
+def _coco_generate_macro_impl(name, visibility, **kwargs):
+    # Generator attrs are inherited from _coco_generate and forwarded via kwargs.
     _coco_generate(
         name = name,
-        package = package,
-        language = language,
-        mocks = mocks,
-        c_file_name_mangler = c_file_name_mangler,
-        c_flat_file_hierarchy = c_flat_file_hierarchy,
-        c_header_file_extension = c_header_file_extension,
-        c_header_file_prefix = c_header_file_prefix,
-        c_implementation_file_extension = c_implementation_file_extension,
-        c_implementation_file_prefix = c_implementation_file_prefix,
-        c_regenerate_packages = c_regenerate_packages,
-        cpp_file_name_mangler = cpp_file_name_mangler,
-        cpp_flat_file_hierarchy = cpp_flat_file_hierarchy,
-        cpp_header_file_extension = cpp_header_file_extension,
-        cpp_header_file_prefix = cpp_header_file_prefix,
-        cpp_implementation_file_extension = cpp_implementation_file_extension,
-        cpp_implementation_file_prefix = cpp_implementation_file_prefix,
-        cpp_regenerate_packages = cpp_regenerate_packages,
-        csharp_regenerate_packages = csharp_regenerate_packages,
+        visibility = visibility,
         **kwargs
     )
+
+    # Companion target for the generated test sources/headers. Only visibility is
+    # forwarded (kwargs holds generator-only attrs); see test/visibility_propagation.
     _coco_test_outputs(
         name = coco_test_outputs_name(name),
         package = name,
-        **kwargs
+        visibility = visibility,
     )
+
+coco_generate = macro(
+    doc = """Generate C, C++, or C# code from a Coco package.
+
+The generated files can then be compiled into libraries or executables using
+standard build rules (e.g., cc_library for C/C++).
+
+The generator configuration options (file extensions, prefixes, etc.) must
+match the settings in your Coco.toml file under the corresponding generator
+section (e.g., [generator.cpp] for C++, [generator.c] for C).
+
+Alongside the main code-generation target, a companion `<name>.tst` target is
+created that exposes the generated test sources and headers.""",
+    inherit_attrs = _coco_generate,
+    implementation = _coco_generate_macro_impl,
+)
 
 def _popili_version_alias_impl(ctx):
     toolchain = ctx.toolchains["@rules_coco//coco:toolchain_type"]

--- a/coco/private/diagram.bzl
+++ b/coco/private/diagram.bzl
@@ -105,34 +105,43 @@ _coco_architecture_diagram = rule(
         ),
         "component_names": attr.bool(
             default = False,
+            doc = "Show the instance name of child components. Disabled by default.",
         ),
         "component_targets": attr.string_list(
             mandatory = True,
         ),
         "component_types": attr.bool(
             default = True,
+            doc = "Show the type of each component. Enabled by default.",
         ),
         "depth": attr.string(
             default = "",
+            doc = "Recursive drawing depth: an integer string, 'auto', 'max', or empty for the default.",
         ),
         "hide_ports": attr.bool(
             default = False,
+            doc = "Hide ports in diagrams. Disabled by default.",
         ),
         "only_encapsulating": attr.bool(
             default = True,
+            doc = "Don't draw implementation/external components. Enabled by default.",
         ),
         "only_roots": attr.bool(
             default = False,
+            doc = "Only draw root components. Disabled by default.",
         ),
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
+            doc = "The coco_package target to generate architecture diagrams for.",
         ),
         "port_names": attr.bool(
             default = False,
+            doc = "Show the instance name of each port. Disabled by default.",
         ),
         "port_types": attr.bool(
             default = True,
+            doc = "Show the type of each port. Enabled by default.",
         ),
     }.items()),
     toolchains = [COCO_TOOLCHAIN_TYPE],
@@ -196,12 +205,16 @@ _coco_state_diagram = rule(
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
+            doc = "The coco_package target to generate state diagrams for.",
         ),
         "separate_edges": attr.bool(
             default = False,
+            doc = "Lay out each state transition as a separate edge. Disabled by default.",
         ),
         "targets": attr.string_list(
             default = [],
+            doc = "Fully qualified names of state machines/components/ports to diagram " +
+                  "(e.g. \"MyComponent.myPort.stateMachine\"). If empty, all state machines are drawn.",
         ),
     }.items()),
     toolchains = [COCO_TOOLCHAIN_TYPE],
@@ -295,85 +308,56 @@ _coco_counterexample_diagram = rule(
     toolchains = [COCO_TOOLCHAIN_TYPE],
 )
 
-# Public macros with platform selection
+# Public macros
 
-def coco_architecture_diagram(
-        name,
-        package,
-        components,
-        port_names = False,
-        port_types = True,
-        component_names = False,
-        component_types = True,
-        depth = "",
-        hide_ports = False,
-        only_encapsulating = True,
-        only_roots = False,
-        **kwargs):
-    """Creates architecture diagrams.
-
-    Generates SVG diagrams showing component architecture using `popili graph-component`.
-
-    Args:
-        name: Name of the diagram target
-        package: The coco_package target to generate architecture diagrams for
-        components: Dict mapping output filenames to component names (e.g., {"my_component.svg": "MyComponent"})
-        port_names: Show instance name of each port (default: False)
-        port_types: Show type of each port (default: True)
-        component_names: Show instance name of child components (default: False)
-        component_types: Show type of each component (default: True)
-        depth: Recursive drawing depth: integer string, 'auto', 'max', or empty for default
-        hide_ports: Hide ports in diagrams (default: False)
-        only_encapsulating: Don't draw implementation/external components (default: True)
-        only_roots: Only draw root components (default: False)
-        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
-    """
+def _coco_architecture_diagram_macro_impl(name, visibility, components, **kwargs):
     if not components:
         fail("components must specify at least one component to diagram")
 
-    # Process the components dict into parallel lists
-    filenames = []
-    targets = []
-
-    for filename, component in components.items():
-        filenames.append(filename)
-        targets.append(component)
-
+    # components is {filename: component}; keys()/values() stay aligned by insertion order.
     _coco_architecture_diagram(
         name = name,
-        package = package,
-        component_filenames = filenames,
-        component_targets = targets,
-        port_names = port_names,
-        port_types = port_types,
-        component_names = component_names,
-        component_types = component_types,
-        depth = depth,
-        hide_ports = hide_ports,
-        only_encapsulating = only_encapsulating,
-        only_roots = only_roots,
+        component_filenames = components.keys(),
+        component_targets = components.values(),
+        visibility = visibility,
         **kwargs
     )
 
-def coco_state_diagram(name, package, targets = [], separate_edges = False, **kwargs):
-    """Creates state machine diagrams.
+coco_architecture_diagram = macro(
+    doc = """Creates architecture diagrams.
 
-    Generates SVG diagrams showing state machine structure using `popili graph-states`.
+Generates SVG diagrams showing component architecture using
+`popili graph-component`.""",
+    inherit_attrs = _coco_architecture_diagram,
+    attrs = {
+        # Hidden from callers: supplied by the impl from `components`.
+        "component_filenames": None,
+        "component_targets": None,
+        "components": attr.string_dict(
+            mandatory = True,
+            configurable = False,
+            doc = "Maps each output SVG filename to the component to draw " +
+                  "(e.g. {\"my_component.svg\": \"MyComponent\"}).",
+        ),
+    },
+    implementation = _coco_architecture_diagram_macro_impl,
+)
 
-    Args:
-        name: Name of the diagram target
-        package: The coco_package target to generate state diagrams for
-        targets: List of fully qualified names of state machines/components/ports to generate diagrams for. If empty, generates diagrams for all state machines (e.g., ["MyComponent.myPort.stateMachine"])
-        separate_edges: Layout option for state transitions (default: False)
-        **kwargs: Additional Bazel arguments (e.g., visibility, tags)
-    """
+def _coco_state_diagram_macro_impl(name, visibility, **kwargs):
     _coco_state_diagram(
         name = name,
-        package = package,
-        targets = targets,
-        separate_edges = separate_edges,
+        visibility = visibility,
         **kwargs
     )
+
+coco_state_diagram = macro(
+    doc = """Creates state machine diagrams.
+
+Generates SVG diagrams showing state machine structure using
+`popili graph-states`.""",
+    inherit_attrs = _coco_state_diagram,
+    implementation = _coco_state_diagram_macro_impl,
+)
 
 def coco_counterexample_diagram(
         name,

--- a/coco/private/format.bzl
+++ b/coco/private/format.bzl
@@ -19,6 +19,7 @@ load(
     "COCO_TOOLCHAIN_TYPE",
     "CocoPackageInfo",
     "LICENSE_ATTRIBUTES",
+    "WINDOWS_CONSTRAINT_ATTR",
     "coco_runfiles",
     "create_coco_wrapper_script",
 )
@@ -45,12 +46,12 @@ def _coco_fmt_test_impl(ctx):
 _coco_fmt_test = rule(
     implementation = _coco_fmt_test_impl,
     attrs = dict(LICENSE_ATTRIBUTES.items() + {
-        "is_windows": attr.bool(mandatory = True),
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
             doc = "The coco_package target to check formatting for",
         ),
+        "_windows_constraint": WINDOWS_CONSTRAINT_ATTR,
     }.items()),
     doc = """Test rule that verifies Coco code formatting.
 
@@ -106,12 +107,12 @@ def _coco_fmt_binary_impl(ctx):
 _coco_fmt_binary = rule(
     implementation = _coco_fmt_binary_impl,
     attrs = dict(LICENSE_ATTRIBUTES.items() + {
-        "is_windows": attr.bool(mandatory = True),
         "package": attr.label(
             providers = [CocoPackageInfo],
             mandatory = True,
             doc = "The coco_package target to format",
         ),
+        "_windows_constraint": WINDOWS_CONSTRAINT_ATTR,
     }.items()),
     doc = """Binary rule that formats Coco code.
 
@@ -128,46 +129,44 @@ be used directly.
     ],
 )
 
-def coco_fmt_test(name, package, **kwargs):
-    """Creates both a format test and a format binary.
-
-    This macro creates two targets:
-    1. A test target (with the given name) that checks formatting via `bazel test`
-    2. A binary target (with _test suffix removed) that formats code via `bazel run`
-
-    For example, if you create `coco_fmt_test(name = "my_pkg_fmt_test", ...)`,
-    two targets are generated:
-    - `my_pkg_fmt_test`: Test that fails if code isn't formatted correctly
-    - `my_pkg_fmt`: Binary to format the code in-place
-
-    Args:
-        name: The name of the test target. Should typically end with '_test'.
-        package: The coco_package target to check/format.
-        **kwargs: Additional arguments forwarded to both rules (e.g., tags, visibility).
-    """
-    is_windows_select = select({
-        "@platforms//os:windows": True,
-        "//conditions:default": False,
-    })
-
-    # Create the test target
+def _coco_fmt_test_macro_impl(name, visibility, package, **kwargs):
+    # Test target (the macro's primary target); test attrs flow through kwargs.
     _coco_fmt_test(
         name = name,
         package = package,
-        is_windows = is_windows_select,
+        visibility = visibility,
         **kwargs
     )
 
-    # Create the formatter binary target
-    # If name ends with _test, create a binary without that suffix
-    binary_name = name[:-5] if name.endswith("_test") else name + "_format"
-
-    # Filter out test-only attributes for the binary target
-    binary_kwargs = {k: v for k, v in kwargs.items() if k != "size" and k != "timeout"}
-
+    # Companion `bazel run` formatter. Named "<name>.format" because symbolic-macro
+    # naming requires the macro-name prefix; only non-test attrs are forwarded.
     _coco_fmt_binary(
-        name = binary_name,
+        name = name + ".format",
         package = package,
-        is_windows = is_windows_select,
-        **binary_kwargs
+        visibility = visibility,
+        tags = kwargs.get("tags"),
     )
+
+coco_fmt_test = macro(
+    doc = """Create a Coco format-check test plus a companion formatter binary.
+
+Two targets are created:
+
+- `<name>`: a test (run via `bazel test`) that fails if the package's Coco
+  sources are not correctly formatted (runs `popili format --verify`).
+- `<name>.format`: a binary (run via `bazel run`) that formats the sources in
+  place (runs `popili format`).
+
+To skip the test for specific packages, use standard Bazel tags, e.g.
+`tags = ["manual"]`.""",
+    inherit_attrs = _coco_fmt_test,
+    attrs = {
+        "package": attr.label(
+            providers = [CocoPackageInfo],
+            mandatory = True,
+            configurable = False,
+            doc = "The coco_package target to check/format.",
+        ),
+    },
+    implementation = _coco_fmt_test_macro_impl,
+)

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -55,42 +55,6 @@ Information about a Coco workspace root whose shared settings flow down to membe
 | <a id="CocoWorkspaceInfo-files"></a>files |  Coco.toml files a member must ship: this workspace's root manifest plus any parent workspaces    |
 
 
-<a id="coco_architecture_diagram"></a>
-
-## coco_architecture_diagram
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_architecture_diagram")
-
-coco_architecture_diagram(<a href="#coco_architecture_diagram-name">name</a>, <a href="#coco_architecture_diagram-package">package</a>, <a href="#coco_architecture_diagram-components">components</a>, <a href="#coco_architecture_diagram-port_names">port_names</a>, <a href="#coco_architecture_diagram-port_types">port_types</a>, <a href="#coco_architecture_diagram-component_names">component_names</a>,
-                          <a href="#coco_architecture_diagram-component_types">component_types</a>, <a href="#coco_architecture_diagram-depth">depth</a>, <a href="#coco_architecture_diagram-hide_ports">hide_ports</a>, <a href="#coco_architecture_diagram-only_encapsulating">only_encapsulating</a>, <a href="#coco_architecture_diagram-only_roots">only_roots</a>,
-                          <a href="#coco_architecture_diagram-kwargs">**kwargs</a>)
-</pre>
-
-Creates architecture diagrams.
-
-Generates SVG diagrams showing component architecture using `popili graph-component`.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_architecture_diagram-name"></a>name |  Name of the diagram target   |  none |
-| <a id="coco_architecture_diagram-package"></a>package |  The coco_package target to generate architecture diagrams for   |  none |
-| <a id="coco_architecture_diagram-components"></a>components |  Dict mapping output filenames to component names (e.g., {"my_component.svg": "MyComponent"})   |  none |
-| <a id="coco_architecture_diagram-port_names"></a>port_names |  Show instance name of each port (default: False)   |  `False` |
-| <a id="coco_architecture_diagram-port_types"></a>port_types |  Show type of each port (default: True)   |  `True` |
-| <a id="coco_architecture_diagram-component_names"></a>component_names |  Show instance name of child components (default: False)   |  `False` |
-| <a id="coco_architecture_diagram-component_types"></a>component_types |  Show type of each component (default: True)   |  `True` |
-| <a id="coco_architecture_diagram-depth"></a>depth |  Recursive drawing depth: integer string, 'auto', 'max', or empty for default   |  `""` |
-| <a id="coco_architecture_diagram-hide_ports"></a>hide_ports |  Hide ports in diagrams (default: False)   |  `False` |
-| <a id="coco_architecture_diagram-only_encapsulating"></a>only_encapsulating |  Don't draw implementation/external components (default: True)   |  `True` |
-| <a id="coco_architecture_diagram-only_roots"></a>only_roots |  Only draw root components (default: False)   |  `False` |
-| <a id="coco_architecture_diagram-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
-
-
 <a id="coco_counterexample_diagram"></a>
 
 ## coco_counterexample_diagram
@@ -121,145 +85,6 @@ are generated). Use coco_verify_test for actual verification testing.
 | <a id="coco_counterexample_diagram-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
 
 
-<a id="coco_fmt_test"></a>
-
-## coco_fmt_test
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_fmt_test")
-
-coco_fmt_test(<a href="#coco_fmt_test-name">name</a>, <a href="#coco_fmt_test-package">package</a>, <a href="#coco_fmt_test-kwargs">**kwargs</a>)
-</pre>
-
-Creates both a format test and a format binary.
-
-This macro creates two targets:
-1. A test target (with the given name) that checks formatting via `bazel test`
-2. A binary target (with _test suffix removed) that formats code via `bazel run`
-
-For example, if you create `coco_fmt_test(name = "my_pkg_fmt_test", ...)`,
-two targets are generated:
-- `my_pkg_fmt_test`: Test that fails if code isn't formatted correctly
-- `my_pkg_fmt`: Binary to format the code in-place
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_fmt_test-name"></a>name |  The name of the test target. Should typically end with '_test'.   |  none |
-| <a id="coco_fmt_test-package"></a>package |  The coco_package target to check/format.   |  none |
-| <a id="coco_fmt_test-kwargs"></a>kwargs |  Additional arguments forwarded to both rules (e.g., tags, visibility).   |  none |
-
-
-<a id="coco_generate"></a>
-
-## coco_generate
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_generate")
-
-coco_generate(<a href="#coco_generate-name">name</a>, <a href="#coco_generate-package">package</a>, <a href="#coco_generate-language">language</a>, <a href="#coco_generate-mocks">mocks</a>, <a href="#coco_generate-c_file_name_mangler">c_file_name_mangler</a>, <a href="#coco_generate-c_flat_file_hierarchy">c_flat_file_hierarchy</a>,
-              <a href="#coco_generate-c_header_file_extension">c_header_file_extension</a>, <a href="#coco_generate-c_header_file_prefix">c_header_file_prefix</a>, <a href="#coco_generate-c_implementation_file_extension">c_implementation_file_extension</a>,
-              <a href="#coco_generate-c_implementation_file_prefix">c_implementation_file_prefix</a>, <a href="#coco_generate-c_regenerate_packages">c_regenerate_packages</a>, <a href="#coco_generate-cpp_file_name_mangler">cpp_file_name_mangler</a>,
-              <a href="#coco_generate-cpp_flat_file_hierarchy">cpp_flat_file_hierarchy</a>, <a href="#coco_generate-cpp_header_file_extension">cpp_header_file_extension</a>, <a href="#coco_generate-cpp_header_file_prefix">cpp_header_file_prefix</a>,
-              <a href="#coco_generate-cpp_implementation_file_extension">cpp_implementation_file_extension</a>, <a href="#coco_generate-cpp_implementation_file_prefix">cpp_implementation_file_prefix</a>,
-              <a href="#coco_generate-cpp_regenerate_packages">cpp_regenerate_packages</a>, <a href="#coco_generate-csharp_regenerate_packages">csharp_regenerate_packages</a>, <a href="#coco_generate-kwargs">**kwargs</a>)
-</pre>
-
-Generate C, C++, or C# code from a Coco package.
-
-This macro generates code from Coco source files in the specified language.
-The generated files can then be compiled into libraries or executables using
-standard build rules (e.g., cc_library for C/C++).
-
-The generator configuration options (file extensions, prefixes, etc.) must match
-the settings in your Coco.toml file under the corresponding generator section
-(e.g., [generator.cpp] for C++, [generator.c] for C).
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_generate-name"></a>name |  Name of the code generation target   |  none |
-| <a id="coco_generate-package"></a>package |  The coco_package target containing the source files to generate from   |  none |
-| <a id="coco_generate-language"></a>language |  Target language for code generation: "cpp", "c", or "csharp"   |  none |
-| <a id="coco_generate-mocks"></a>mocks |  Generate mock implementations for testing (default: False)   |  `False` |
-| <a id="coco_generate-c_file_name_mangler"></a>c_file_name_mangler |  C file naming style - must match Coco.toml generator.c.fileNameMangler. Options: "Unaltered", "LowerCamelCase", "UpperCamelCase", "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore"   |  `"Unaltered"` |
-| <a id="coco_generate-c_flat_file_hierarchy"></a>c_flat_file_hierarchy |  Use flat directory structure for C files - must match Coco.toml generator.c.flatFileHierarchy   |  `False` |
-| <a id="coco_generate-c_header_file_extension"></a>c_header_file_extension |  File extension for C headers (default: ".h")   |  `".h"` |
-| <a id="coco_generate-c_header_file_prefix"></a>c_header_file_prefix |  Prefix for C header file names (default: "")   |  `""` |
-| <a id="coco_generate-c_implementation_file_extension"></a>c_implementation_file_extension |  File extension for C implementation files (default: ".c")   |  `".c"` |
-| <a id="coco_generate-c_implementation_file_prefix"></a>c_implementation_file_prefix |  Prefix for C implementation file names (default: "")   |  `""` |
-| <a id="coco_generate-c_regenerate_packages"></a>c_regenerate_packages |  List of other coco_package targets to regenerate with this target's C generator settings   |  `[]` |
-| <a id="coco_generate-cpp_file_name_mangler"></a>cpp_file_name_mangler |  C++ file naming style - must match Coco.toml generator.cpp.fileNameMangler. Options: "Unaltered", "LowerCamelCase", "UpperCamelCase", "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore"   |  `"Unaltered"` |
-| <a id="coco_generate-cpp_flat_file_hierarchy"></a>cpp_flat_file_hierarchy |  Use flat directory structure for C++ files - must match Coco.toml generator.cpp.flatFileHierarchy   |  `False` |
-| <a id="coco_generate-cpp_header_file_extension"></a>cpp_header_file_extension |  File extension for C++ headers (default: ".h")   |  `".h"` |
-| <a id="coco_generate-cpp_header_file_prefix"></a>cpp_header_file_prefix |  Prefix for C++ header file names (default: "")   |  `""` |
-| <a id="coco_generate-cpp_implementation_file_extension"></a>cpp_implementation_file_extension |  File extension for C++ implementation files (default: ".cc")   |  `".cc"` |
-| <a id="coco_generate-cpp_implementation_file_prefix"></a>cpp_implementation_file_prefix |  Prefix for C++ implementation file names (default: "")   |  `""` |
-| <a id="coco_generate-cpp_regenerate_packages"></a>cpp_regenerate_packages |  List of other coco_package targets to regenerate with this target's C++ generator settings   |  `[]` |
-| <a id="coco_generate-csharp_regenerate_packages"></a>csharp_regenerate_packages |  List of other coco_package targets to regenerate with this target's C# generator settings   |  `[]` |
-| <a id="coco_generate-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
-
-
-<a id="coco_package"></a>
-
-## coco_package
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_package")
-
-coco_package(<a href="#coco_package-name">name</a>, <a href="#coco_package-package">package</a>, <a href="#coco_package-srcs">srcs</a>, <a href="#coco_package-deps">deps</a>, <a href="#coco_package-test_srcs">test_srcs</a>, <a href="#coco_package-typecheck">typecheck</a>, <a href="#coco_package-workspace">workspace</a>, <a href="#coco_package-kwargs">**kwargs</a>)
-</pre>
-
-Define a Coco package from Coco.toml and .coco source files.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_package-name"></a>name |  Name of the package target   |  none |
-| <a id="coco_package-package"></a>package |  Label pointing to the Coco.toml file for this package   |  none |
-| <a id="coco_package-srcs"></a>srcs |  List of .coco source files for this package   |  none |
-| <a id="coco_package-deps"></a>deps |  List of other coco_package targets this package depends on   |  `[]` |
-| <a id="coco_package-test_srcs"></a>test_srcs |  List of .coco test source files   |  `[]` |
-| <a id="coco_package-typecheck"></a>typecheck |  Run typecheck validation during package creation. When enabled, the build will fail if typecheck errors are found.   |  `False` |
-| <a id="coco_package-workspace"></a>workspace |  Optional coco_workspace whose Coco.toml settings this package inherits   |  `None` |
-| <a id="coco_package-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
-
-
-<a id="coco_state_diagram"></a>
-
-## coco_state_diagram
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_state_diagram")
-
-coco_state_diagram(<a href="#coco_state_diagram-name">name</a>, <a href="#coco_state_diagram-package">package</a>, <a href="#coco_state_diagram-targets">targets</a>, <a href="#coco_state_diagram-separate_edges">separate_edges</a>, <a href="#coco_state_diagram-kwargs">**kwargs</a>)
-</pre>
-
-Creates state machine diagrams.
-
-Generates SVG diagrams showing state machine structure using `popili graph-states`.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_state_diagram-name"></a>name |  Name of the diagram target   |  none |
-| <a id="coco_state_diagram-package"></a>package |  The coco_package target to generate state diagrams for   |  none |
-| <a id="coco_state_diagram-targets"></a>targets |  List of fully qualified names of state machines/components/ports to generate diagrams for. If empty, generates diagrams for all state machines (e.g., ["MyComponent.myPort.stateMachine"])   |  `[]` |
-| <a id="coco_state_diagram-separate_edges"></a>separate_edges |  Layout option for state transitions (default: False)   |  `False` |
-| <a id="coco_state_diagram-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
-
-
 <a id="coco_test_outputs_name"></a>
 
 ## coco_test_outputs_name
@@ -278,59 +103,6 @@ coco_test_outputs_name(<a href="#coco_test_outputs_name-name">name</a>)
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="coco_test_outputs_name-name"></a>name |  <p align="center"> - </p>   |  none |
-
-
-<a id="coco_verify_test"></a>
-
-## coco_verify_test
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_verify_test")
-
-coco_verify_test(<a href="#coco_verify_test-name">name</a>, <a href="#coco_verify_test-package">package</a>, <a href="#coco_verify_test-kwargs">**kwargs</a>)
-</pre>
-
-Creates a test that runs Coco verification on a package.
-
-This test executes the `popili verify` command on the specified coco_package,
-verifying the Coco code.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_verify_test-name"></a>name |  Name of the test target   |  none |
-| <a id="coco_verify_test-package"></a>package |  The coco_package target to verify   |  none |
-| <a id="coco_verify_test-kwargs"></a>kwargs |  Additional Bazel test arguments (e.g., size, timeout, tags, visibility)   |  none |
-
-
-<a id="coco_workspace"></a>
-
-## coco_workspace
-
-<pre>
-load("@rules_coco//coco:defs.bzl", "coco_workspace")
-
-coco_workspace(<a href="#coco_workspace-name">name</a>, <a href="#coco_workspace-workspace">workspace</a>, <a href="#coco_workspace-parent">parent</a>, <a href="#coco_workspace-kwargs">**kwargs</a>)
-</pre>
-
-Declares a Coco workspace root.
-
-A workspace's Coco.toml carries shared settings that popili applies to member
-packages. Reference this target from a coco_package's `workspace` attribute.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="coco_workspace-name"></a>name |  Name of the workspace target   |  none |
-| <a id="coco_workspace-workspace"></a>workspace |  Label pointing to the workspace's root Coco.toml   |  none |
-| <a id="coco_workspace-parent"></a>parent |  Optional parent coco_workspace target, for nested workspaces   |  `None` |
-| <a id="coco_workspace-kwargs"></a>kwargs |  Additional Bazel arguments (e.g., visibility, tags)   |  none |
 
 
 <a id="counterexample_options"></a>
@@ -356,5 +128,341 @@ Specify counterexample filtering options.
 **RETURNS**
 
 Struct with decl and assertion fields for use in coco_counterexample_diagram
+
+
+<a id="coco_architecture_diagram"></a>
+
+## coco_architecture_diagram
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_architecture_diagram")
+
+coco_architecture_diagram(*, <a href="#coco_architecture_diagram-name">name</a>, <a href="#coco_architecture_diagram-compatible_with">compatible_with</a>, <a href="#coco_architecture_diagram-component_names">component_names</a>, <a href="#coco_architecture_diagram-component_types">component_types</a>, <a href="#coco_architecture_diagram-components">components</a>,
+                          <a href="#coco_architecture_diagram-deprecation">deprecation</a>, <a href="#coco_architecture_diagram-depth">depth</a>, <a href="#coco_architecture_diagram-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_architecture_diagram-exec_properties">exec_properties</a>, <a href="#coco_architecture_diagram-features">features</a>,
+                          <a href="#coco_architecture_diagram-hide_ports">hide_ports</a>, <a href="#coco_architecture_diagram-only_encapsulating">only_encapsulating</a>, <a href="#coco_architecture_diagram-only_roots">only_roots</a>, <a href="#coco_architecture_diagram-package">package</a>, <a href="#coco_architecture_diagram-package_metadata">package_metadata</a>,
+                          <a href="#coco_architecture_diagram-port_names">port_names</a>, <a href="#coco_architecture_diagram-port_types">port_types</a>, <a href="#coco_architecture_diagram-restricted_to">restricted_to</a>, <a href="#coco_architecture_diagram-tags">tags</a>, <a href="#coco_architecture_diagram-target_compatible_with">target_compatible_with</a>,
+                          <a href="#coco_architecture_diagram-testonly">testonly</a>, <a href="#coco_architecture_diagram-toolchains">toolchains</a>, <a href="#coco_architecture_diagram-visibility">visibility</a>)
+</pre>
+
+Creates architecture diagrams.
+
+Generates SVG diagrams showing component architecture using
+`popili graph-component`.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_architecture_diagram-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_architecture_diagram-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-component_names"></a>component_names |  Show the instance name of child components. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-component_types"></a>component_types |  Show the type of each component. Enabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-components"></a>components |  Maps each output SVG filename to the component to draw (e.g. {"my_component.svg": "MyComponent"}).   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | required |  |
+| <a id="coco_architecture_diagram-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-depth"></a>depth |  Recursive drawing depth: an integer string, 'auto', 'max', or empty for the default.   | String | optional |  `None`  |
+| <a id="coco_architecture_diagram-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_architecture_diagram-hide_ports"></a>hide_ports |  Hide ports in diagrams. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-only_encapsulating"></a>only_encapsulating |  Don't draw implementation/external components. Enabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-only_roots"></a>only_roots |  Only draw root components. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-package"></a>package |  The coco_package target to generate architecture diagrams for.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="coco_architecture_diagram-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-port_names"></a>port_names |  Show the instance name of each port. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-port_types"></a>port_types |  Show the type of each port. Enabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_architecture_diagram-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_architecture_diagram-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+
+
+<a id="coco_fmt_test"></a>
+
+## coco_fmt_test
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_fmt_test")
+
+coco_fmt_test(*, <a href="#coco_fmt_test-name">name</a>, <a href="#coco_fmt_test-args">args</a>, <a href="#coco_fmt_test-compatible_with">compatible_with</a>, <a href="#coco_fmt_test-deprecation">deprecation</a>, <a href="#coco_fmt_test-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_fmt_test-exec_properties">exec_properties</a>,
+              <a href="#coco_fmt_test-features">features</a>, <a href="#coco_fmt_test-flaky">flaky</a>, <a href="#coco_fmt_test-local">local</a>, <a href="#coco_fmt_test-package">package</a>, <a href="#coco_fmt_test-package_metadata">package_metadata</a>, <a href="#coco_fmt_test-restricted_to">restricted_to</a>, <a href="#coco_fmt_test-shard_count">shard_count</a>, <a href="#coco_fmt_test-size">size</a>,
+              <a href="#coco_fmt_test-tags">tags</a>, <a href="#coco_fmt_test-target_compatible_with">target_compatible_with</a>, <a href="#coco_fmt_test-testonly">testonly</a>, <a href="#coco_fmt_test-timeout">timeout</a>, <a href="#coco_fmt_test-toolchains">toolchains</a>, <a href="#coco_fmt_test-visibility">visibility</a>)
+</pre>
+
+Create a Coco format-check test plus a companion formatter binary.
+
+Two targets are created:
+
+- `<name>`: a test (run via `bazel test`) that fails if the package's Coco
+  sources are not correctly formatted (runs `popili format --verify`).
+- `<name>.format`: a binary (run via `bazel run`) that formats the sources in
+  place (runs `popili format`).
+
+To skip the test for specific packages, use standard Bazel tags, e.g.
+`tags = ["manual"]`.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_fmt_test-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_fmt_test-args"></a>args |  <a href="https://bazel.build/reference/be/common-definitions#test.args">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_fmt_test-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_fmt_test-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_fmt_test-flaky"></a>flaky |  <a href="https://bazel.build/reference/be/common-definitions#test.flaky">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-local"></a>local |  <a href="https://bazel.build/reference/be/common-definitions#test.local">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-package"></a>package |  The coco_package target to check/format.   | <a href="https://bazel.build/concepts/labels">Label</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | required |  |
+| <a id="coco_fmt_test-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-shard_count"></a>shard_count |  <a href="https://bazel.build/reference/be/common-definitions#test.shard_count">Inherited rule attribute</a>   | Integer | optional |  `None`  |
+| <a id="coco_fmt_test-size"></a>size |  <a href="https://bazel.build/reference/be/common-definitions#test.size">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_fmt_test-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-timeout"></a>timeout |  <a href="https://bazel.build/reference/be/common-definitions#test.timeout">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_fmt_test-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_fmt_test-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+
+
+<a id="coco_generate"></a>
+
+## coco_generate
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_generate")
+
+coco_generate(*, <a href="#coco_generate-name">name</a>, <a href="#coco_generate-c_file_name_mangler">c_file_name_mangler</a>, <a href="#coco_generate-c_flat_file_hierarchy">c_flat_file_hierarchy</a>, <a href="#coco_generate-c_header_file_extension">c_header_file_extension</a>,
+              <a href="#coco_generate-c_header_file_prefix">c_header_file_prefix</a>, <a href="#coco_generate-c_implementation_file_extension">c_implementation_file_extension</a>, <a href="#coco_generate-c_implementation_file_prefix">c_implementation_file_prefix</a>,
+              <a href="#coco_generate-c_regenerate_packages">c_regenerate_packages</a>, <a href="#coco_generate-compatible_with">compatible_with</a>, <a href="#coco_generate-cpp_file_name_mangler">cpp_file_name_mangler</a>, <a href="#coco_generate-cpp_flat_file_hierarchy">cpp_flat_file_hierarchy</a>,
+              <a href="#coco_generate-cpp_header_file_extension">cpp_header_file_extension</a>, <a href="#coco_generate-cpp_header_file_prefix">cpp_header_file_prefix</a>, <a href="#coco_generate-cpp_implementation_file_extension">cpp_implementation_file_extension</a>,
+              <a href="#coco_generate-cpp_implementation_file_prefix">cpp_implementation_file_prefix</a>, <a href="#coco_generate-cpp_regenerate_packages">cpp_regenerate_packages</a>, <a href="#coco_generate-csharp_regenerate_packages">csharp_regenerate_packages</a>,
+              <a href="#coco_generate-deprecation">deprecation</a>, <a href="#coco_generate-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_generate-exec_properties">exec_properties</a>, <a href="#coco_generate-features">features</a>, <a href="#coco_generate-language">language</a>, <a href="#coco_generate-mocks">mocks</a>, <a href="#coco_generate-package">package</a>,
+              <a href="#coco_generate-package_metadata">package_metadata</a>, <a href="#coco_generate-restricted_to">restricted_to</a>, <a href="#coco_generate-tags">tags</a>, <a href="#coco_generate-target_compatible_with">target_compatible_with</a>, <a href="#coco_generate-testonly">testonly</a>, <a href="#coco_generate-toolchains">toolchains</a>,
+              <a href="#coco_generate-visibility">visibility</a>)
+</pre>
+
+Generate C, C++, or C# code from a Coco package.
+
+The generated files can then be compiled into libraries or executables using
+standard build rules (e.g., cc_library for C/C++).
+
+The generator configuration options (file extensions, prefixes, etc.) must
+match the settings in your Coco.toml file under the corresponding generator
+section (e.g., [generator.cpp] for C++, [generator.c] for C).
+
+Alongside the main code-generation target, a companion `<name>.tst` target is
+created that exposes the generated test sources and headers.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_generate-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_generate-c_file_name_mangler"></a>c_file_name_mangler |  C file naming style. Must match Coco.toml generator.c.fileNameMangler. Options: "Unaltered" (default), "LowerCamelCase", "UpperCamelCase", "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore".   | String | optional |  `None`  |
+| <a id="coco_generate-c_flat_file_hierarchy"></a>c_flat_file_hierarchy |  Use a flat directory structure for C files. Must match Coco.toml generator.c.flatFileHierarchy. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_generate-c_header_file_extension"></a>c_header_file_extension |  File extension for C headers. Defaults to ".h".   | String | optional |  `None`  |
+| <a id="coco_generate-c_header_file_prefix"></a>c_header_file_prefix |  Prefix for C header file names. Empty by default.   | String | optional |  `None`  |
+| <a id="coco_generate-c_implementation_file_extension"></a>c_implementation_file_extension |  File extension for C implementation files. Defaults to ".c".   | String | optional |  `None`  |
+| <a id="coco_generate-c_implementation_file_prefix"></a>c_implementation_file_prefix |  Prefix for C implementation file names. Empty by default.   | String | optional |  `None`  |
+| <a id="coco_generate-c_regenerate_packages"></a>c_regenerate_packages |  Other coco_package targets to regenerate with this target's C generator settings.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_generate-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-cpp_file_name_mangler"></a>cpp_file_name_mangler |  C++ file naming style. Must match Coco.toml generator.cpp.fileNameMangler. Options: "Unaltered" (default), "LowerCamelCase", "UpperCamelCase", "LowerUnderscore", "UpperUnderscore", "CapsUpperUnderscore".   | String | optional |  `None`  |
+| <a id="coco_generate-cpp_flat_file_hierarchy"></a>cpp_flat_file_hierarchy |  Use a flat directory structure for C++ files. Must match Coco.toml generator.cpp.flatFileHierarchy. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_generate-cpp_header_file_extension"></a>cpp_header_file_extension |  File extension for C++ headers. Defaults to ".h".   | String | optional |  `None`  |
+| <a id="coco_generate-cpp_header_file_prefix"></a>cpp_header_file_prefix |  Prefix for C++ header file names. Empty by default.   | String | optional |  `None`  |
+| <a id="coco_generate-cpp_implementation_file_extension"></a>cpp_implementation_file_extension |  File extension for C++ implementation files. Defaults to ".cc".   | String | optional |  `None`  |
+| <a id="coco_generate-cpp_implementation_file_prefix"></a>cpp_implementation_file_prefix |  Prefix for C++ implementation file names. Empty by default.   | String | optional |  `None`  |
+| <a id="coco_generate-cpp_regenerate_packages"></a>cpp_regenerate_packages |  Other coco_package targets to regenerate with this target's C++ generator settings.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_generate-csharp_regenerate_packages"></a>csharp_regenerate_packages |  Other coco_package targets to regenerate with this target's C# generator settings.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_generate-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_generate-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_generate-language"></a>language |  Target language for code generation: "cpp", "c", or "csharp".   | String | required |  |
+| <a id="coco_generate-mocks"></a>mocks |  Generate mock implementations for testing. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_generate-package"></a>package |  The coco_package target containing the source files to generate from.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="coco_generate-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_generate-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_generate-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_generate-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+
+
+<a id="coco_package"></a>
+
+## coco_package
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_package")
+
+coco_package(*, <a href="#coco_package-name">name</a>, <a href="#coco_package-deps">deps</a>, <a href="#coco_package-srcs">srcs</a>, <a href="#coco_package-compatible_with">compatible_with</a>, <a href="#coco_package-deprecation">deprecation</a>, <a href="#coco_package-exec_compatible_with">exec_compatible_with</a>,
+             <a href="#coco_package-exec_properties">exec_properties</a>, <a href="#coco_package-features">features</a>, <a href="#coco_package-package">package</a>, <a href="#coco_package-package_metadata">package_metadata</a>, <a href="#coco_package-restricted_to">restricted_to</a>, <a href="#coco_package-tags">tags</a>,
+             <a href="#coco_package-target_compatible_with">target_compatible_with</a>, <a href="#coco_package-test_srcs">test_srcs</a>, <a href="#coco_package-testonly">testonly</a>, <a href="#coco_package-toolchains">toolchains</a>, <a href="#coco_package-typecheck">typecheck</a>, <a href="#coco_package-visibility">visibility</a>,
+             <a href="#coco_package-workspace">workspace</a>)
+</pre>
+
+Define a Coco package from a Coco.toml and its .coco source files.
+
+A coco_package is the unit the other Coco rules operate on: pass it to
+coco_generate to produce code, to coco_verify_test to verify it, or to
+coco_fmt_test to check formatting. Packages may depend on other packages via
+`deps`, and may inherit shared settings from a coco_workspace via `workspace`.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_package-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_package-deps"></a>deps |  Other coco_package targets this package depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_package-srcs"></a>srcs |  The .coco source files for this package.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="coco_package-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_package-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_package-package"></a>package |  Label pointing to the Coco.toml file for this package.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="coco_package-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_package-test_srcs"></a>test_srcs |  The .coco test source files for this package.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_package-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_package-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_package-typecheck"></a>typecheck |  Run typecheck validation during package creation. When enabled, the build fails if typecheck errors are found. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_package-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+| <a id="coco_package-workspace"></a>workspace |  Optional coco_workspace whose Coco.toml settings this package inherits.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+
+
+<a id="coco_state_diagram"></a>
+
+## coco_state_diagram
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_state_diagram")
+
+coco_state_diagram(*, <a href="#coco_state_diagram-name">name</a>, <a href="#coco_state_diagram-compatible_with">compatible_with</a>, <a href="#coco_state_diagram-deprecation">deprecation</a>, <a href="#coco_state_diagram-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_state_diagram-exec_properties">exec_properties</a>,
+                   <a href="#coco_state_diagram-features">features</a>, <a href="#coco_state_diagram-package">package</a>, <a href="#coco_state_diagram-package_metadata">package_metadata</a>, <a href="#coco_state_diagram-restricted_to">restricted_to</a>, <a href="#coco_state_diagram-separate_edges">separate_edges</a>, <a href="#coco_state_diagram-tags">tags</a>,
+                   <a href="#coco_state_diagram-target_compatible_with">target_compatible_with</a>, <a href="#coco_state_diagram-targets">targets</a>, <a href="#coco_state_diagram-testonly">testonly</a>, <a href="#coco_state_diagram-toolchains">toolchains</a>, <a href="#coco_state_diagram-visibility">visibility</a>)
+</pre>
+
+Creates state machine diagrams.
+
+Generates SVG diagrams showing state machine structure using
+`popili graph-states`.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_state_diagram-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_state_diagram-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_state_diagram-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_state_diagram-package"></a>package |  The coco_package target to generate state diagrams for.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="coco_state_diagram-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-separate_edges"></a>separate_edges |  Lay out each state transition as a separate edge. Disabled by default.   | Boolean | optional |  `None`  |
+| <a id="coco_state_diagram-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_state_diagram-targets"></a>targets |  Fully qualified names of state machines/components/ports to diagram (e.g. "MyComponent.myPort.stateMachine"). If empty, all state machines are drawn.   | List of strings | optional |  `None`  |
+| <a id="coco_state_diagram-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_state_diagram-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_state_diagram-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+
+
+<a id="coco_verify_test"></a>
+
+## coco_verify_test
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_verify_test")
+
+coco_verify_test(*, <a href="#coco_verify_test-name">name</a>, <a href="#coco_verify_test-args">args</a>, <a href="#coco_verify_test-compatible_with">compatible_with</a>, <a href="#coco_verify_test-deprecation">deprecation</a>, <a href="#coco_verify_test-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_verify_test-exec_properties">exec_properties</a>,
+                 <a href="#coco_verify_test-features">features</a>, <a href="#coco_verify_test-flaky">flaky</a>, <a href="#coco_verify_test-local">local</a>, <a href="#coco_verify_test-package">package</a>, <a href="#coco_verify_test-package_metadata">package_metadata</a>, <a href="#coco_verify_test-restricted_to">restricted_to</a>, <a href="#coco_verify_test-shard_count">shard_count</a>, <a href="#coco_verify_test-size">size</a>,
+                 <a href="#coco_verify_test-tags">tags</a>, <a href="#coco_verify_test-target_compatible_with">target_compatible_with</a>, <a href="#coco_verify_test-testonly">testonly</a>, <a href="#coco_verify_test-timeout">timeout</a>, <a href="#coco_verify_test-toolchains">toolchains</a>, <a href="#coco_verify_test-visibility">visibility</a>)
+</pre>
+
+Creates a test that runs Coco verification on a package.
+
+Executes `popili verify` on the specified coco_package, failing the test if
+verification does not pass.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_verify_test-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_verify_test-args"></a>args |  <a href="https://bazel.build/reference/be/common-definitions#test.args">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_verify_test-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_verify_test-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_verify_test-flaky"></a>flaky |  <a href="https://bazel.build/reference/be/common-definitions#test.flaky">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-local"></a>local |  <a href="https://bazel.build/reference/be/common-definitions#test.local">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-package"></a>package |  The coco_package target to verify.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="coco_verify_test-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-shard_count"></a>shard_count |  <a href="https://bazel.build/reference/be/common-definitions#test.shard_count">Inherited rule attribute</a>   | Integer | optional |  `None`  |
+| <a id="coco_verify_test-size"></a>size |  <a href="https://bazel.build/reference/be/common-definitions#test.size">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_verify_test-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-timeout"></a>timeout |  <a href="https://bazel.build/reference/be/common-definitions#test.timeout">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_verify_test-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_verify_test-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+
+
+<a id="coco_workspace"></a>
+
+## coco_workspace
+
+<pre>
+load("@rules_coco//coco:defs.bzl", "coco_workspace")
+
+coco_workspace(*, <a href="#coco_workspace-name">name</a>, <a href="#coco_workspace-compatible_with">compatible_with</a>, <a href="#coco_workspace-deprecation">deprecation</a>, <a href="#coco_workspace-exec_compatible_with">exec_compatible_with</a>, <a href="#coco_workspace-exec_properties">exec_properties</a>,
+               <a href="#coco_workspace-features">features</a>, <a href="#coco_workspace-package_metadata">package_metadata</a>, <a href="#coco_workspace-parent">parent</a>, <a href="#coco_workspace-restricted_to">restricted_to</a>, <a href="#coco_workspace-tags">tags</a>, <a href="#coco_workspace-target_compatible_with">target_compatible_with</a>,
+               <a href="#coco_workspace-testonly">testonly</a>, <a href="#coco_workspace-toolchains">toolchains</a>, <a href="#coco_workspace-visibility">visibility</a>, <a href="#coco_workspace-workspace">workspace</a>)
+</pre>
+
+Declares a Coco workspace root.
+
+A workspace's Coco.toml carries shared settings that popili applies to member
+packages. Reference this target from a coco_package's `workspace` attribute.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco_workspace-name"></a>name |  A unique name for this macro instance. Normally, this is also the name for the macro's main or only target. The names of any other targets that this macro might create will be this name with a string suffix.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="coco_workspace-compatible_with"></a>compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-deprecation"></a>deprecation |  <a href="https://bazel.build/reference/be/common-definitions#common.deprecation">Inherited rule attribute</a>   | String; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-exec_compatible_with"></a>exec_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-exec_properties"></a>exec_properties |  <a href="https://bazel.build/reference/be/common-definitions#common.exec_properties">Inherited rule attribute</a>   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `None`  |
+| <a id="coco_workspace-features"></a>features |  <a href="https://bazel.build/reference/be/common-definitions#common.features">Inherited rule attribute</a>   | List of strings | optional |  `None`  |
+| <a id="coco_workspace-package_metadata"></a>package_metadata |  <a href="https://bazel.build/reference/be/common-definitions#common.package_metadata">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-parent"></a>parent |  An enclosing coco_workspace, when this workspace is nested inside another   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="coco_workspace-restricted_to"></a>restricted_to |  <a href="https://bazel.build/reference/be/common-definitions#common.restricted_to">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-tags"></a>tags |  <a href="https://bazel.build/reference/be/common-definitions#common.tags">Inherited rule attribute</a>   | List of strings; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-target_compatible_with"></a>target_compatible_with |  <a href="https://bazel.build/reference/be/common-definitions#common.target_compatible_with">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_workspace-testonly"></a>testonly |  <a href="https://bazel.build/reference/be/common-definitions#common.testonly">Inherited rule attribute</a>   | Boolean; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
+| <a id="coco_workspace-toolchains"></a>toolchains |  <a href="https://bazel.build/reference/be/common-definitions#common.toolchains">Inherited rule attribute</a>   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `None`  |
+| <a id="coco_workspace-visibility"></a>visibility |  The visibility to be passed to this macro's exported targets. It always implicitly includes the location where this macro is instantiated, so this attribute only needs to be explicitly set if you want the macro's targets to be additionally visible somewhere else.   | <a href="https://bazel.build/concepts/labels">List of labels</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  |
+| <a id="coco_workspace-workspace"></a>workspace |  Label pointing to the workspace's root Coco.toml (must contain a [workspace] section)   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/test/simple/BUILD
+++ b/test/simple/BUILD
@@ -31,7 +31,7 @@ coco_verify_test(
 
 # This creates two targets:
 # - base_fmt_test: Test that checks formatting (bazel test //test/simple:base_fmt_test)
-# - base_fmt: Binary that formats the code (bazel run //test/simple:base_fmt)
+# - base_fmt_test.format: Binary that formats the code (bazel run //test/simple:base_fmt_test.format)
 coco_fmt_test(
     name = "base_fmt_test",
     package = ":base",


### PR DESCRIPTION
Port coco_generate, coco_package, coco_fmt_test, coco_workspace, coco_verify_test, coco_state_diagram and coco_architecture_diagram to symbolic macros via inherit_attrs, with per-argument docs moved onto the rule attributes.