### PR TITLE
feat(rules): support local and bring-your-own popili toolchains

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -211,6 +211,19 @@ jobs:
           for dir in e2e/*/; do
             dir=${dir%/}  # Remove trailing slash
 
+            # Skip bzlmod-only scenarios (no WORKSPACE file) when testing workspace mode.
+            if [ "${{ matrix.build_system }}" = "workspace" ] && [ ! -f "$dir/WORKSPACE" ]; then
+              echo "Skipping ${dir} (no WORKSPACE; bzlmod-only)"
+              continue
+            fi
+
+            # Run a scenario's setup hook if present.
+            if [ -f "$dir/stage.py" ]; then
+              echo "Staging ${dir}..."
+              PY=$(command -v python3 || command -v python)
+              "$PY" "$dir/stage.py"
+            fi
+
             # Skip multi_version for action_file mode - it uses popili 1.5.0
             # which doesn't support --machine-auth-token (requires 1.5.2+)
             if [ "${{ matrix.license_source }}" = "action_file" ] && [ "$dir" = "e2e/multi_version" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Coco workspaces are now supported via the new `coco_workspace` rule and `workspace` attribute on `coco_package`.
+- `coco.local_toolchain` allows you to point `rules_coco` at a `popili` on the local filesystem instead of a downloaded
+  release. See the README section "Using a local toolchain".
+- Documented how you can use `rules_coco` with your own `popili` toolchain obtained from other bazel rules. See the
+  README section "Bring your own toolchain".
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,54 @@ There are several ways of setting the version of Popili that you would like to u
 
    See `e2e/multi_version` for a full example.
 
+### Using a local toolchain
+
+To point at a popili toolchain on the local filesystem instead of a download add `coco.local_toolchain` to
+`MODULE.bazel`:
+
+```starlark
+coco = use_extension("@rules_coco//coco:extensions.bzl", "coco")
+coco.local_toolchain(
+    popili = "/path/to/popili-dist",      # holds the popili + cocotec-licensing-server binaries
+    cc_runtime = "/path/to/cpp-runtime",  # optional: holds the `coco/` subtree
+    # c_runtime = "/path/to/c-runtime",   # optional: holds the `coco_c/` subtree
+)
+```
+
+Each path (absolute, or workspace-relative) mirrors the **extracted release archive layout** — i.e. the contents
+of `popili_<os>_<arch>.zip`, `coco-cpp-runtime.zip`, and `coco-c-runtime.zip` respectively. To use it, run with
+`bazel build --@rules_coco//:version=local //...` (consider a `.bazelrc` `--config`).
+
+For `WORKSPACE` mode use `coco_local_repositories(path=..., cc_runtime_path=..., c_runtime_path=...)` instead;
+it has no version flag, so the registered toolchain is simply the active one. See `e2e/local_toolchain`.
+
+### Bring your own toolchain
+
+To point at a popili toolchain obtained from other bazel rules you can register your own `coco_toolchain` and skip
+rules_coco's toolchain machinery entirely. In `MODULE.bazel` you just need
+
+```starlark
+register_toolchains("//tools:my_popili_tc")
+```
+
+```starlark
+# tools/BUILD.bazel
+load("@rules_coco//coco:toolchain.bzl", "coco_toolchain")
+
+coco_toolchain(
+    name = "my_popili",
+    coco = "//path/to:popili",
+    cocotec_licensing_server = "//path/to:cocotec-licensing-server",
+    # cc_runtime = "//path/to:cpp_runtime",  # optional cc_library, for coco_cc_library
+)
+
+toolchain(
+    name = "my_popili_tc",
+    toolchain = ":my_popili",
+    toolchain_type = "@rules_coco//coco:toolchain_type",
+)
+```
+
 ### Using an older C++ compiler (Boost libraries)
 
 Most users can skip this section. The Coco C++ runtime compiles cleanly on any toolchain that supports C++11 or

--- a/coco/extensions.bzl
+++ b/coco/extensions.bzl
@@ -20,7 +20,9 @@ load(
 )
 load(
     "//coco/private:common_repositories.bzl",
+    "coco_c_local_runtime_repository",
     "coco_c_runtime_repository",
+    "coco_cc_local_runtime_repository",
     "coco_cc_runtime_repository",
     "coco_fetch_license_repository",
     "coco_preferences_repository",
@@ -30,6 +32,7 @@ load(
 )
 load(
     "//coco/private:repositories.bzl",
+    "coco_local_toolchain_repository",
     "coco_toolchain_repository",
     "coco_toolchain_repository_proxy",
 )
@@ -167,6 +170,16 @@ def _toolchain_tag_impl(ctx):
             if not auth_token_path and toolchain.auth_token_path:
                 auth_token_path = toolchain.auth_token_path
 
+    # Root-module only: a dependency must not force a machine-specific path on consumers.
+    local_tag = None
+    for mod in ctx.modules:
+        for tag in mod.tags.local_toolchain:
+            if not mod.is_root:
+                fail("coco.local_toolchain is only allowed in the root module (requested by module '%s')." % mod.name)
+            if local_tag != None:
+                fail("coco.local_toolchain may be specified at most once.")
+            local_tag = tag
+
     # Resolve version aliases (like "stable" -> "1.5.1") and deduplicate
     # Keep track of both original and resolved versions for config_settings
     versions = []  # Resolved versions for toolchain creation
@@ -302,6 +315,43 @@ def _toolchain_tag_impl(ctx):
                 target_compatible_with[default_toolchain_name] = constraints
                 target_settings[default_toolchain_name] = ["@coco_toolchains//:version_default"]
 
+    # Host-only (no constraints), gated on the "local" version so it needs --version=local.
+    if local_tag:
+        version_suffixes["local"] = "local"
+
+        cc_runtime_label = None
+        if local_tag.cc_runtime:
+            coco_cc_local_runtime_repository(
+                name = "io_cocotec_coco_cc_runtime__local",
+                path = local_tag.cc_runtime,
+            )
+            cc_runtime_label = "@io_cocotec_coco_cc_runtime__local//:runtime"
+
+        c_runtime_label = None
+        if local_tag.c_runtime:
+            coco_c_local_runtime_repository(
+                name = "io_cocotec_coco_c_runtime__local",
+                path = local_tag.c_runtime,
+            )
+            c_runtime_label = "@io_cocotec_coco_c_runtime__local//:runtime"
+
+        local_repo_name = "io_cocotec_coco_local"
+        coco_local_toolchain_repository(
+            name = local_repo_name,
+            path = local_tag.popili,
+            cc_runtime_label = cc_runtime_label,
+            c_runtime_label = c_runtime_label,
+            license_source = license_source,
+            license_token = license_token,
+            auth_token_path = auth_token_path,
+        )
+
+        toolchain_names.append("local")
+        toolchain_labels["local"] = "@%s//:toolchain_impl" % local_repo_name
+        exec_compatible_with["local"] = []
+        target_compatible_with["local"] = []
+        target_settings["local"] = ["@coco_toolchains//:version_local"]
+
     # Create hub repository that aggregates all toolchains
     _coco_toolchain_hub(
         name = "coco_toolchains",
@@ -313,8 +363,9 @@ def _toolchain_tag_impl(ctx):
         version_suffixes = version_suffixes,
     )
 
+    # A local path isn't reproducible.
     return ctx.extension_metadata(
-        reproducible = True,
+        reproducible = local_tag == None,
     )
 
 _toolchain_tag = tag_class(
@@ -364,10 +415,34 @@ _cc_runtime_deps_tag = tag_class(
     },
 )
 
+_local_toolchain_tag = tag_class(
+    doc = (
+        "Register a Coco toolchain from a popili distribution on the local filesystem, " +
+        "instead of fetching a published release. Root-module only, at most once. Used " +
+        "only under --@rules_coco//:version=local. Paths mirror the extracted release " +
+        "archive layout; see the rules_coco README."
+    ),
+    attrs = {
+        "c_runtime": attr.string(
+            doc = "Optional path to a dir holding the C runtime 'coco_c/' subtree. Absolute or workspace-relative.",
+            default = "",
+        ),
+        "cc_runtime": attr.string(
+            doc = "Optional path to a dir holding the C++ runtime 'coco/' subtree. Absolute or workspace-relative.",
+            default = "",
+        ),
+        "popili": attr.string(
+            doc = "Path to a dir holding the 'popili' and 'cocotec-licensing-server' binaries. Absolute or workspace-relative.",
+            mandatory = True,
+        ),
+    },
+)
+
 coco = module_extension(
     implementation = _toolchain_tag_impl,
     tag_classes = {
         "cc_runtime_deps": _cc_runtime_deps_tag,
+        "local_toolchain": _local_toolchain_tag,
         "toolchain": _toolchain_tag,
     },
 )

--- a/coco/private/common_repositories.bzl
+++ b/coco/private/common_repositories.bzl
@@ -36,6 +36,17 @@ cc_library(
 )
 """
 
+_C_RUNTIME_BUILD = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "runtime",
+    hdrs = glob(["coco_c/*.h"]),
+    srcs = glob(["coco_c/src/*.c"], allow_empty = True) + glob(["coco_c/*.c"], allow_empty = True),
+    visibility = ["//visibility:public"],
+)
+"""
+
 # Known license file version suffixes to check for
 KNOWN_VERSION_SUFFIXES = [
     "_6",
@@ -217,22 +228,72 @@ def _coco_c_runtime_repository_impl(ctx):
 
     ctx.file("WORKSPACE", """workspace(name = "{}")""".format(ctx.name))
 
-    ctx.file("BUILD.bazel", """
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-cc_library(
-    name = "runtime",
-    hdrs = glob(["coco_c/*.h"]),
-    srcs = glob(["coco_c/src/*.c"], allow_empty = True) + glob(["coco_c/*.c"], allow_empty = True),
-    visibility = ["//visibility:public"],
-)
-""")
+    ctx.file("BUILD.bazel", _C_RUNTIME_BUILD)
 
 _coco_c_runtime_repository = repository_rule(
     implementation = _coco_c_runtime_repository_impl,
     attrs = {
         "version": attr.string(
             doc = "The version of coco/popili to download C runtime for",
+            mandatory = True,
+        ),
+    },
+)
+
+def _is_absolute(path):
+    # Matches skylib's paths.is_absolute; inlined because this file is loaded before
+    # skylib is fetched in WORKSPACE mode, so we can't load it here.
+    return path.startswith("/") or (len(path) > 2 and path[1] == ":")
+
+def resolve_local_path(ctx, path):
+    """Resolves a local_toolchain path: absolute as-is, relative against the workspace root.
+
+    ctx.path resolves a bare relative string against the generated repo, not the
+    consuming workspace, so relative paths must be anchored explicitly.
+    """
+    if _is_absolute(path):
+        return ctx.path(path)
+    return ctx.path("%s/%s" % (ctx.workspace_root, path))
+
+def _coco_cc_local_runtime_repository_impl(ctx):
+    """C++ runtime repository symlinked from a local path instead of downloaded."""
+    runtime_dir = resolve_local_path(ctx, ctx.attr.path).get_child("coco")
+    if not runtime_dir.exists:
+        fail("Local C++ runtime path '%s' does not contain a 'coco' directory" % ctx.attr.path)
+    ctx.symlink(runtime_dir, "coco")
+
+    ctx.file("WORKSPACE", """workspace(name = "{}")""".format(ctx.name))
+    ctx.file("BUILD.bazel", _CC_RUNTIME_BUILD_TEMPLATE.format(deps = "[]"))
+
+_coco_cc_local_runtime_repository = repository_rule(
+    implementation = _coco_cc_local_runtime_repository_impl,
+    # Reevaluated on every fetch so a replaced runtime tree is picked up.
+    local = True,
+    attrs = {
+        "path": attr.string(
+            doc = "Local filesystem path to a directory containing the C++ runtime `coco/` subtree.",
+            mandatory = True,
+        ),
+    },
+)
+
+def _coco_c_local_runtime_repository_impl(ctx):
+    """C runtime repository symlinked from a local path instead of downloaded."""
+    runtime_dir = resolve_local_path(ctx, ctx.attr.path).get_child("coco_c")
+    if not runtime_dir.exists:
+        fail("Local C runtime path '%s' does not contain a 'coco_c' directory" % ctx.attr.path)
+    ctx.symlink(runtime_dir, "coco_c")
+
+    ctx.file("WORKSPACE", """workspace(name = "{}")""".format(ctx.name))
+    ctx.file("BUILD.bazel", _C_RUNTIME_BUILD)
+
+_coco_c_local_runtime_repository = repository_rule(
+    implementation = _coco_c_local_runtime_repository_impl,
+    # Reevaluated on every fetch so a replaced runtime tree is picked up.
+    local = True,
+    attrs = {
+        "path": attr.string(
+            doc = "Local filesystem path to a directory containing the C runtime `coco_c/` subtree.",
             mandatory = True,
         ),
     },
@@ -373,8 +434,10 @@ _coco_symlink_license_repository = repository_rule(
 
 # Public API - these are the functions/rules that should be imported
 coco_c_runtime_repository = _coco_c_runtime_repository
+coco_c_local_runtime_repository = _coco_c_local_runtime_repository
 coco_cc_repositories = _coco_cc_repositories
 coco_cc_runtime_repository = _coco_cc_runtime_repository
+coco_cc_local_runtime_repository = _coco_cc_local_runtime_repository
 coco_preferences_repository = _coco_preferences_repository
 coco_fetch_license_repository = _coco_fetch_license_repository
 coco_symlink_license_repository = _coco_symlink_license_repository

--- a/coco/private/repositories.bzl
+++ b/coco/private/repositories.bzl
@@ -18,12 +18,15 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     ":common_repositories.bzl",
     "KNOWN_VERSION_SUFFIXES",
+    "coco_c_local_runtime_repository",
     "coco_c_runtime_repository",
+    "coco_cc_local_runtime_repository",
     "coco_cc_repositories",
     "coco_fetch_license_repository",
     "coco_preferences_repository",
     "coco_symlink_license_repository",
     "download_prefix",
+    "resolve_local_path",
     "validate_minimum_version",
     "version_to_repo_suffix",
 )
@@ -202,6 +205,67 @@ coco_toolchain_repository = repository_rule(
     implementation = _coco_toolchain_repository_impl,
 )
 
+def _coco_local_toolchain_repository_impl(ctx):
+    """Coco toolchain repository symlinked from a local path instead of downloaded.
+
+    Host-only, and the product is always "popili" (no os/arch/version attrs, unlike
+    the download rule).
+    """
+    dist_dir = resolve_local_path(ctx, ctx.attr.path)
+
+    # Take the extension from what's actually staged rather than guessing the host OS.
+    binary_ext = ".exe" if dist_dir.get_child("popili.exe").exists else ""
+    for binary in ["popili", "cocotec-licensing-server"]:
+        src = dist_dir.get_child(binary + binary_ext)
+        if not src.exists:
+            fail("Local popili path '%s' does not contain '%s'" % (ctx.attr.path, binary + binary_ext))
+        ctx.symlink(src, "bin/" + binary + binary_ext)
+
+    ctx.file("WORKSPACE", "")
+    ctx.file("BUILD", "\n".join([
+        BUILD_for_coco_archive(binary_ext = binary_ext, product = "popili"),
+        BUILD_for_coco_toolchain(
+            name = "toolchain",
+            cc_runtime_label = ctx.attr.cc_runtime_label,
+            c_runtime_label = ctx.attr.c_runtime_label,
+            license_source = ctx.attr.license_source,
+            license_token = ctx.attr.license_token,
+            auth_token_path = ctx.attr.auth_token_path,
+        ),
+    ]))
+
+coco_local_toolchain_repository = repository_rule(
+    attrs = {
+        "auth_token_path": attr.string(
+            doc = "Optional auth token file path string",
+            default = "",
+        ),
+        "c_runtime_label": attr.label(
+            doc = "Optional label to the C runtime library",
+            default = None,
+        ),
+        "cc_runtime_label": attr.label(
+            doc = "Optional label to the C++ runtime library",
+            default = None,
+        ),
+        "license_source": attr.string(
+            doc = "Optional license source mode (e.g., 'local_user', 'local_acquire', 'token', 'action_environment', 'action_file')",
+            default = "",
+        ),
+        "license_token": attr.string(
+            doc = "Optional license token string",
+            default = "",
+        ),
+        "path": attr.string(
+            doc = "Local filesystem path to a directory containing the popili and cocotec-licensing-server binaries at its top level.",
+            mandatory = True,
+        ),
+    },
+    implementation = _coco_local_toolchain_repository_impl,
+    # Reevaluated on every fetch so a replaced binary is picked up.
+    local = True,
+)
+
 coco_toolchain_repository_proxy = repository_rule(
     attrs = {
         "constraints": attr.string_list(),
@@ -351,17 +415,15 @@ def coco_repositories(version = "stable", **kwargs):
             auth_token_path = auth_token_path,
         )
 
-def coco_local_repository_set(name, path):
-    native.new_local_repository(
+def coco_local_repository_set(name, path, cc_runtime_label = None, c_runtime_label = None, license_source = None, license_token = None, auth_token_path = None):
+    coco_local_toolchain_repository(
         name = name,
         path = path,
-        build_file_content = "\n".join([
-            BUILD_for_coco_archive(binary_ext = "", product = "popili"),
-            BUILD_for_coco_toolchain(
-                name = "toolchain",
-            ),
-        ]),
-        workspace_file_content = "",
+        cc_runtime_label = cc_runtime_label,
+        c_runtime_label = c_runtime_label,
+        license_source = license_source,
+        license_token = license_token,
+        auth_token_path = auth_token_path,
     )
 
     coco_toolchain_repository_proxy(
@@ -375,12 +437,59 @@ def coco_local_repository_set(name, path):
         name = name,
     ))
 
-def coco_local_repositories(path, **kwargs):
-    _coco_deps(
-        version = "stable",
-        **kwargs
-    )
+def coco_local_repositories(path, cc_runtime_path = None, c_runtime_path = None, **kwargs):
+    """Sets up Coco toolchain repositories from a local popili path (WORKSPACE mode).
+
+    Use this to point the rules at a popili distribution already present on the local
+    filesystem (one you download and manage yourself, or an internal build) instead of
+    having rules_coco fetch a published release.
+
+    Unlike the bzlmod `coco.local_toolchain` tag (which is gated behind
+    `--@rules_coco//:version=local`), WORKSPACE mode has no version flag plumbing, so
+    the local toolchain registered here becomes the active Coco toolchain for the build.
+
+    Args:
+      path: Directory containing the `popili` and `cocotec-licensing-server`
+        binaries at its top level (the extracted popili archive layout).
+      cc_runtime_path: Optional directory containing the local C++ runtime `coco/` subtree.
+        Required to build `coco_cc_library` against the local toolchain.
+      c_runtime_path: Optional directory containing the local C runtime `coco_c/` subtree.
+        Required to build `coco_c_library` against the local toolchain.
+      **kwargs: Additional arguments:
+
+          license_source (str): Optional default license source mode. See `coco_repositories`.
+
+          license_token (str): Optional default license token.
+
+          auth_token_path (str): Optional auth token file path.
+    """
+
+    # Nothing is downloaded (toolchain/runtimes are local); version only picks the
+    # licensing product name.
+    _coco_deps(version = "stable")
+
+    cc_runtime_label = None
+    if cc_runtime_path:
+        coco_cc_local_runtime_repository(
+            name = "io_cocotec_coco_cc_runtime__local",
+            path = cc_runtime_path,
+        )
+        cc_runtime_label = "@io_cocotec_coco_cc_runtime__local//:runtime"
+
+    c_runtime_label = None
+    if c_runtime_path:
+        coco_c_local_runtime_repository(
+            name = "io_cocotec_coco_c_runtime__local",
+            path = c_runtime_path,
+        )
+        c_runtime_label = "@io_cocotec_coco_c_runtime__local//:runtime"
+
     coco_local_repository_set(
         name = "coco_local",
         path = path,
+        cc_runtime_label = cc_runtime_label,
+        c_runtime_label = c_runtime_label,
+        license_source = kwargs.get("license_source", None),
+        license_token = kwargs.get("license_token", None),
+        auth_token_path = kwargs.get("auth_token_path", None),
     )

--- a/coco/repositories.bzl
+++ b/coco/repositories.bzl
@@ -16,7 +16,9 @@
 
 load(
     "//coco/private:repositories.bzl",
+    _coco_local_repositories = "coco_local_repositories",
     _coco_repositories = "coco_repositories",
 )
 
 coco_repositories = _coco_repositories
+coco_local_repositories = _coco_local_repositories

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,6 +9,7 @@ Bazel module extensions for rules_coco.
 <pre>
 coco = use_extension("@rules_coco//coco:extensions.bzl", "coco")
 coco.cc_runtime_deps(<a href="#coco.cc_runtime_deps-deps">deps</a>, <a href="#coco.cc_runtime_deps-version">version</a>)
+coco.local_toolchain(<a href="#coco.local_toolchain-c_runtime">c_runtime</a>, <a href="#coco.local_toolchain-cc_runtime">cc_runtime</a>, <a href="#coco.local_toolchain-popili">popili</a>)
 coco.toolchain(<a href="#coco.toolchain-auth_token_path">auth_token_path</a>, <a href="#coco.toolchain-c">c</a>, <a href="#coco.toolchain-cc">cc</a>, <a href="#coco.toolchain-license_source">license_source</a>, <a href="#coco.toolchain-license_token">license_token</a>, <a href="#coco.toolchain-versions">versions</a>)
 </pre>
 
@@ -27,6 +28,20 @@ Inject extra cc_library deps into the Coco C++ runtime for a specific Coco/Popil
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="coco.cc_runtime_deps-deps"></a>deps |  List of cc_library targets to append to the runtime's deps.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="coco.cc_runtime_deps-version"></a>version |  Coco/Popili version these deps apply to. May be an explicit version (e.g. '1.5.1') or an alias (e.g. 'stable').   | String | required |  |
+
+<a id="coco.local_toolchain"></a>
+
+### local_toolchain
+
+Register a Coco toolchain from a popili distribution on the local filesystem, instead of fetching a published release. Root-module only, at most once. Used only under --@rules_coco//:version=local. Paths mirror the extracted release archive layout; see the rules_coco README.
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="coco.local_toolchain-c_runtime"></a>c_runtime |  Optional path to a dir holding the C runtime 'coco_c/' subtree. Absolute or workspace-relative.   | String | optional |  `""`  |
+| <a id="coco.local_toolchain-cc_runtime"></a>cc_runtime |  Optional path to a dir holding the C++ runtime 'coco/' subtree. Absolute or workspace-relative.   | String | optional |  `""`  |
+| <a id="coco.local_toolchain-popili"></a>popili |  Path to a dir holding the 'popili' and 'cocotec-licensing-server' binaries. Absolute or workspace-relative.   | String | required |  |
 
 <a id="coco.toolchain"></a>
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -2,6 +2,38 @@
 
 Public API for Coco repository rules.
 
+<a id="coco_local_repositories"></a>
+
+## coco_local_repositories
+
+<pre>
+load("@rules_coco//coco:repositories.bzl", "coco_local_repositories")
+
+coco_local_repositories(<a href="#coco_local_repositories-path">path</a>, <a href="#coco_local_repositories-cc_runtime_path">cc_runtime_path</a>, <a href="#coco_local_repositories-c_runtime_path">c_runtime_path</a>, <a href="#coco_local_repositories-kwargs">**kwargs</a>)
+</pre>
+
+Sets up Coco toolchain repositories from a local popili path (WORKSPACE mode).
+
+Use this to point the rules at a popili distribution already present on the local
+filesystem (one you download and manage yourself, or an internal build) instead of
+having rules_coco fetch a published release.
+
+Unlike the bzlmod `coco.local_toolchain` tag (which is gated behind
+`--@rules_coco//:version=local`), WORKSPACE mode has no version flag plumbing, so
+the local toolchain registered here becomes the active Coco toolchain for the build.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="coco_local_repositories-path"></a>path |  Directory containing the `popili` and `cocotec-licensing-server` binaries at its top level (the extracted popili archive layout).   |  none |
+| <a id="coco_local_repositories-cc_runtime_path"></a>cc_runtime_path |  Optional directory containing the local C++ runtime `coco/` subtree. Required to build `coco_cc_library` against the local toolchain.   |  `None` |
+| <a id="coco_local_repositories-c_runtime_path"></a>c_runtime_path |  Optional directory containing the local C runtime `coco_c/` subtree. Required to build `coco_c_library` against the local toolchain.   |  `None` |
+| <a id="coco_local_repositories-kwargs"></a>kwargs |  Additional arguments:<br><br>license_source (str): Optional default license source mode. See `coco_repositories`.<br><br>license_token (str): Optional default license token.<br><br>auth_token_path (str): Optional auth token file path.   |  none |
+
+
 <a id="coco_repositories"></a>
 
 ## coco_repositories

--- a/e2e/byo_toolchain/.bazelrc
+++ b/e2e/byo_toolchain/.bazelrc
@@ -1,0 +1,16 @@
+# For windows we need proper runfiles
+startup --windows_enable_symlinks
+common --enable_runfiles=true
+
+# Enable platform-specific config (build:windows, build:linux, build:macos)
+common --enable_platform_specific_config
+
+common --enable_bzlmod=true
+common:bzlmod --enable_bzlmod=true
+common:workspace --enable_bzlmod=false
+common:workspace --enable_workspace=true
+
+# Windows-specific: Enable conforming preprocessor for proper macro handling
+build:windows --copt=/Zc:preprocessor
+build:windows --host_copt=/Zc:preprocessor
+build:windows --repo_env=BAZEL_SH

--- a/e2e/byo_toolchain/.gitignore
+++ b/e2e/byo_toolchain/.gitignore
@@ -1,0 +1,2 @@
+# Popili binaries staged by stage.py (machine-specific).
+/popili_dist/bin/

--- a/e2e/byo_toolchain/BUILD.bazel
+++ b/e2e/byo_toolchain/BUILD.bazel
@@ -1,0 +1,14 @@
+# Verifies a Coco package using the bring-your-own coco_toolchain.
+
+load("@rules_coco//coco:defs.bzl", "coco_package", "coco_verify_test")
+
+coco_package(
+    name = "byo_toolchain",
+    srcs = glob(["src/**/*.coco"]),
+    package = "Coco.toml",
+)
+
+coco_verify_test(
+    name = "byo_toolchain_verify",
+    package = ":byo_toolchain",
+)

--- a/e2e/byo_toolchain/Coco.toml
+++ b/e2e/byo_toolchain/Coco.toml
@@ -1,0 +1,7 @@
+[package]
+name = "byo_toolchain"
+sources = ["src"]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]

--- a/e2e/byo_toolchain/MODULE.bazel
+++ b/e2e/byo_toolchain/MODULE.bazel
@@ -1,0 +1,21 @@
+# E2E for the "bring your own toolchain" path: a coco_toolchain you register
+# yourself, without invoking the coco toolchain extension at all — the path popili
+# will use to verify in-tree. bzlmod-only (no WORKSPACE file). Run stage.py to
+# populate popili_dist/bin/, then `bazel test`.
+
+module(
+    name = "rules_coco_byo_toolchain_test",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_coco", version = "")
+local_path_override(
+    module_name = "rules_coco",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+
+register_toolchains("//tools:byo_popili_tc")

--- a/e2e/byo_toolchain/popili_dist/BUILD.bazel
+++ b/e2e/byo_toolchain/popili_dist/BUILD.bazel
@@ -1,0 +1,20 @@
+# Exposes the staged bin/ binaries (gitignored) as single-file labels for //tools.
+# Wildcards tolerate the .exe suffix; the exclude drops popili-language-server.
+filegroup(
+    name = "popili",
+    srcs = glob(
+        ["bin/popili*"],
+        allow_empty = True,
+        exclude = ["bin/popili-language-server*"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "licensing_server",
+    srcs = glob(
+        ["bin/cocotec-licensing-server*"],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/e2e/byo_toolchain/src/Example.coco
+++ b/e2e/byo_toolchain/src/Example.coco
@@ -1,0 +1,4 @@
+port Example {
+  function process() : Nil
+  machine { process() = {} }
+}

--- a/e2e/byo_toolchain/stage.py
+++ b/e2e/byo_toolchain/stage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Stage popili into ./popili_dist/bin for the byo_toolchain e2e. See tools/stage_popili.py."""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "tools"))
+import stage_popili  # noqa: E402
+
+stage_popili.main(os.path.join(_HERE, "popili_dist"), binary_subdir="bin")

--- a/e2e/byo_toolchain/tools/BUILD.bazel
+++ b/e2e/byo_toolchain/tools/BUILD.bazel
@@ -1,0 +1,18 @@
+# A bring-your-own coco_toolchain pointing at //popili_dist binaries.
+# register_toolchains lives in MODULE.bazel.
+
+load("@rules_coco//coco:toolchain.bzl", "coco_toolchain")
+
+coco_toolchain(
+    name = "byo_popili",
+    coco = "//popili_dist:popili",
+    cocotec_licensing_server = "//popili_dist:licensing_server",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "byo_popili_tc",
+    toolchain = ":byo_popili",
+    toolchain_type = "@rules_coco//coco:toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/local_toolchain/.bazelrc
+++ b/e2e/local_toolchain/.bazelrc
@@ -1,0 +1,20 @@
+# For windows we need proper runfiles
+startup --windows_enable_symlinks
+common --enable_runfiles=true
+
+# Enable platform-specific config (build:windows, build:linux, build:macos)
+common --enable_platform_specific_config
+
+common --enable_bzlmod=true
+common:bzlmod --enable_bzlmod=true
+common:workspace --enable_bzlmod=false
+common:workspace --enable_workspace=true
+
+# Select the local toolchain (bzlmod). Harmless in WORKSPACE mode, where the
+# local toolchain is registered unconditionally.
+common --@rules_coco//:version=local
+
+# Windows-specific: Enable conforming preprocessor for proper macro handling
+build:windows --copt=/Zc:preprocessor
+build:windows --host_copt=/Zc:preprocessor
+build:windows --repo_env=BAZEL_SH

--- a/e2e/local_toolchain/.gitignore
+++ b/e2e/local_toolchain/.gitignore
@@ -1,0 +1,2 @@
+# Locally-staged popili toolchain (machine-specific).
+/staged/

--- a/e2e/local_toolchain/BUILD.bazel
+++ b/e2e/local_toolchain/BUILD.bazel
@@ -1,0 +1,54 @@
+# E2E local-toolchain test BUILD file.
+# Exercises code generation + verification against a local popili toolchain.
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_coco//coco:cc.bzl", "coco_cc_library", "coco_cc_test_library")
+load("@rules_coco//coco:defs.bzl", "coco_generate", "coco_package", "coco_verify_test")
+
+# Define Coco package
+coco_package(
+    name = "local_toolchain",
+    srcs = glob(["src/**/*.coco"]),
+    package = "Coco.toml",
+)
+
+# Verify the Coco package
+coco_verify_test(
+    name = "local_toolchain_verify",
+    package = ":local_toolchain",
+)
+
+# Generate C++ code from Coco
+coco_generate(
+    name = "local_toolchain_cpp",
+    language = "cpp",
+    mocks = True,
+    package = ":local_toolchain",
+)
+
+# Create C++ library from generated code
+coco_cc_library(
+    name = "local_toolchain_cc",
+    generated_package = ":local_toolchain_cpp",
+)
+
+# Create C++ test library with mocks
+coco_cc_test_library(
+    name = "local_toolchain_cc_tst",
+    generated_package = ":local_toolchain_cpp",
+    deps = [":local_toolchain_cc"],
+)
+
+# C++ binary that uses the generated code
+cc_binary(
+    name = "local_toolchain_bin",
+    srcs = ["test/main.cc"],
+    deps = [":local_toolchain_cc"],
+)
+
+# C++ unit test with GoogleTest
+cc_test(
+    name = "local_toolchain_test",
+    srcs = ["test/local_toolchain_test.cc"],
+    deps = [":local_toolchain_cc_tst"],
+)

--- a/e2e/local_toolchain/Coco.toml
+++ b/e2e/local_toolchain/Coco.toml
@@ -1,0 +1,13 @@
+[package]
+name = "local_toolchain"
+sources = ["src"]
+
+[language]
+standard = "1.2"
+profiles = ["C++"]
+
+[generator]
+defaultLanguage = "C++"
+
+[generator.cpp]
+generateMocks = "GMock"

--- a/e2e/local_toolchain/MODULE.bazel
+++ b/e2e/local_toolchain/MODULE.bazel
@@ -1,0 +1,27 @@
+# E2E for local-toolchain support (coco.local_toolchain), also tested in WORKSPACE
+# mode via the WORKSPACE file. Points at ./staged; run stage.py to populate it, or
+# point at your own toolchain. Then `bazel test` (--config=workspace for WORKSPACE).
+
+module(
+    name = "rules_coco_local_toolchain_test",
+    version = "0.0.0",
+)
+
+# Override rules_coco to use the local development version.
+bazel_dep(name = "rules_coco", version = "")
+local_path_override(
+    module_name = "rules_coco",
+    path = "../..",
+)
+
+# Required dependencies
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+
+coco = use_extension("@rules_coco//coco:extensions.bzl", "coco")
+coco.local_toolchain(
+    cc_runtime = "staged/cpp-runtime",
+    popili = "staged/popili",
+)

--- a/e2e/local_toolchain/WORKSPACE
+++ b/e2e/local_toolchain/WORKSPACE
@@ -1,0 +1,30 @@
+# E2E local-toolchain test WORKSPACE (WORKSPACE mode).
+
+workspace(name = "rules_coco_local_toolchain_test")
+
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
+# Use the local development version of rules_coco.
+local_repository(
+    name = "rules_coco",
+    path = "../..",
+)
+
+load("@rules_coco//coco:repositories.bzl", "coco_local_repositories")
+
+# Register a toolchain from a local popili path (./staged; see stage.py). WORKSPACE
+# has no --@rules_coco//:version flag, so this is simply the active toolchain.
+coco_local_repositories(
+    cc_runtime_path = "staged/cpp-runtime",
+    path = "staged/popili",
+)
+
+# Load GoogleTest for C++ unit tests
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "googletest",
+    sha256 = "12ef65654dc01ab40f6f33f9d02c04f2097d2cd9fbe48dc6001b29543583b0ad",
+    strip_prefix = "googletest-8d51ffdfab10b3fba636ae69bc03da4b54f8c235",
+    urls = ["https://github.com/google/googletest/archive/8d51ffdfab10b3fba636ae69bc03da4b54f8c235.zip"],
+)

--- a/e2e/local_toolchain/src/Example.coco
+++ b/e2e/local_toolchain/src/Example.coco
@@ -1,0 +1,9 @@
+port Example {
+  function process() : Nil
+  machine { process() = {} }
+}
+
+@runtime(.MultiThreaded)
+external component ExampleComponent {
+  val client : Provided<Example>
+}

--- a/e2e/local_toolchain/stage.py
+++ b/e2e/local_toolchain/stage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Stage popili into ./staged for the local_toolchain e2e. See tools/stage_popili.py."""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "tools"))
+import stage_popili  # noqa: E402
+
+stage_popili.main(os.path.join(_HERE, "staged"), binary_subdir="popili", with_cpp_runtime=True)

--- a/e2e/local_toolchain/test/local_toolchain_test.cc
+++ b/e2e/local_toolchain/test/local_toolchain_test.cc
@@ -1,0 +1,20 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "src/Example.h"
+#include "src/ExampleMock.h"
+
+using ::testing::_;
+using ::testing::Exactly;
+
+TEST(LocalToolchainTest, BasicMockTest) {
+  ExampleComponentMock mock;
+  EXPECT_CALL(mock, client_process()).Times(Exactly(1));
+
+  mock.client_process();
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/e2e/local_toolchain/test/main.cc
+++ b/e2e/local_toolchain/test/main.cc
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "src/Example.h"
+
+int main() {
+  std::cout << "Local-toolchain test binary ran successfully!" << std::endl;
+  return 0;
+}

--- a/tools/local_test.py
+++ b/tools/local_test.py
@@ -34,6 +34,18 @@ def discover_e2e_dirs():
     ])
 
 
+def stage_e2e_dirs(e2e_dirs):
+    """Run each e2e directory's stage.py setup hook, if it has one.
+
+    Lets a scenario own its pre-test setup (e.g. local_toolchain stages a popili
+    release into the expected layout). Hooks are expected to be idempotent.
+    """
+    for d in e2e_dirs:
+        hook = os.path.join(d, 'stage.py')
+        if os.path.isfile(hook):
+            subprocess.run([sys.executable, hook], check=True)
+
+
 def main():
     """Run all test configurations."""
     configs = [
@@ -43,11 +55,17 @@ def main():
     ]
 
     e2e_dirs = discover_e2e_dirs()
+    stage_e2e_dirs(e2e_dirs)
     passed = 0
 
     for version, mode in configs:
-        # Run root workspace and all e2e tests
-        test_dirs = [('root workspace', None)] + [(d, d) for d in e2e_dirs]
+        # Run root workspace and all e2e tests. Skip bzlmod-only scenarios (those
+        # without a WORKSPACE file) when testing workspace mode.
+        test_dirs = [('root workspace', None)] + [
+            (d, d)
+            for d in e2e_dirs
+            if mode != 'workspace' or os.path.isfile(os.path.join(d, 'WORKSPACE'))
+        ]
 
         if all(run_bazel_test(name, version, mode, cwd) for name, cwd in test_dirs):
             passed += 1

--- a/tools/stage_popili.py
+++ b/tools/stage_popili.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Shared helper for the e2e stage.py hooks to fake a local popili toolchain.
+
+Downloads the archives for the version rules_coco pins as `stable` and lays the
+binaries (and optionally the C++ runtime) on disk, preserving executable bits.
+"""
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import urllib.request
+import zipfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_VERSION_ALIASES_BZL = os.path.join(_HERE, "..", "coco", "private", "version_aliases.bzl")
+
+
+def stable_version():
+    namespace = {}
+    exec(open(_VERSION_ALIASES_BZL).read(), namespace)
+    return namespace["VERSION_ALIASES"]["stable"]
+
+
+def _os_token(system):
+    return {"Darwin": "darwin", "Linux": "linux", "Windows": "windows"}.get(system)
+
+
+def _arch_token(machine):
+    machine = machine.lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    if machine in ("x86_64", "amd64"):
+        return "amd64"
+    return None
+
+
+def popili_archive():
+    """Returns the popili binary archive name for the host platform."""
+    os_token = _os_token(platform.system())
+    arch_token = _arch_token(platform.machine())
+    if not os_token or not arch_token:
+        sys.exit(f"Unsupported host platform: {platform.system()}/{platform.machine()}.")
+    return f"popili_{os_token}_{arch_token}.zip"
+
+
+def _download_and_extract(base_url, archive, dest, tmp_dir):
+    """Downloads base_url/archive and extracts it into dest, preserving modes."""
+    url = f"{base_url}/{archive}"
+    tmp = os.path.join(tmp_dir, archive)
+    print(f"Downloading {url}")
+    urllib.request.urlretrieve(url, tmp)
+
+    os.makedirs(dest, exist_ok=True)
+    with zipfile.ZipFile(tmp) as zf:
+        for info in zf.infolist():
+            extracted = zf.extract(info, dest)
+            mode = info.external_attr >> 16
+            if mode:
+                os.chmod(extracted, mode)
+    os.remove(tmp)
+
+
+def stage(dest_dir, binary_subdir="popili", with_cpp_runtime=False, force=False):
+    """Stages popili binaries under dest_dir/<binary_subdir> (+ cpp-runtime if asked).
+    """
+    binary_dir = os.path.join(dest_dir, binary_subdir)
+    if os.path.isdir(binary_dir) and not force:
+        print(f"{binary_dir} already present; skipping (pass force=True to refresh).")
+        return
+
+    # Never remove dest_dir itself.
+    shutil.rmtree(binary_dir, ignore_errors=True)
+    runtime_dir = os.path.join(dest_dir, "cpp-runtime")
+    if with_cpp_runtime:
+        shutil.rmtree(runtime_dir, ignore_errors=True)
+    os.makedirs(dest_dir, exist_ok=True)
+
+    version = stable_version()
+    base_url = f"https://dl.cocotec.io/popili/archive/{version}"
+    _download_and_extract(base_url, popili_archive(), binary_dir, dest_dir)
+    if with_cpp_runtime:
+        _download_and_extract(base_url, "coco-cpp-runtime.zip", runtime_dir, dest_dir)
+
+    print(f"Staged popili {version} into {dest_dir}")
+
+
+def main(dest_dir, binary_subdir="popili", with_cpp_runtime=False):
+    """CLI entrypoint for the e2e stage.py shims; adds a --force flag."""
+    parser = argparse.ArgumentParser(description="Stage a popili toolchain for an e2e test.")
+    parser.add_argument("--force", action="store_true", help="Re-download even if already staged.")
+    stage(dest_dir, binary_subdir=binary_subdir, with_cpp_runtime=with_cpp_runtime, force=parser.parse_args().force)


### PR DESCRIPTION
Add coco.local_toolchain (and coco_local_repositories for WORKSPACE) to point rules_coco at a popili + C/C++ runtime on the local filesystem instead of a downloaded release, selected via --@rules_coco//:version=local. Also document the bring-your-own path: invoke the coco extension with no coco.toolchain tag (support repos only, no download) and register your own coco_toolchain at any labels, enabling popili to verify in-tree.